### PR TITLE
Add support for pulling account assignment creation status

### DIFF
--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -30,10 +30,6 @@ const (
 	AccountAssignmentRetryDelay      = 1 * time.Second
 )
 
-var (
-	errCreateAccountAssignmentFailure = errors.New("aws-connector: account assignment creation failed")
-)
-
 type accountResourceType struct {
 	resourceType     *v2.ResourceType
 	orgClient        *awsOrgs.Client


### PR DESCRIPTION
When creating an account assignment(e.g. granting an sso account access to a permission set), it is actually an asynchronous process. This means that it isn't applied immediately, and the successful response from the create API request doesn't mean that provisioning was successful.

In order to validate the provisioning was successful, we must describe the status of the request, and wait for it to return successfully. It is possible for the request to fail for some reason after the fact, so we need to look out for that response, and return an error appropriately.

Unfortunately, this API requires an additional IAM permission that we don't request, so users will need to be update permissions for us to take advantage of this.

We should take a look and see if there are other async operations that we're doing, and generalize the wait loop if possible.