### PR TITLE
Don't early return if there are errors setting up sso/org-related clients.

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -355,27 +355,27 @@ func (c *AWS) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSy
 	if err == nil {
 		rs = append(rs, iamUserBuilder(iamClient), iamRoleBuilder(iamClient), iamGroupBuilder(iamClient))
 	}
+	if !c.ssoEnabled && !c.orgsEnabled {
+		return rs
+	}
+
 	ix, err := c.getIdentityInstance(ctx)
 	if err != nil {
 		l.Error("getIdentityInstance error", zap.Error(err))
-		return rs
 	}
 	ssoAdminClient, err := c.ssoAdminClient(ctx)
 	if err != nil {
 		l.Error("ssoAdminClient error", zap.Error(err))
-		return rs
 	}
 	identityStoreClient, err := c.identityStoreClient(ctx)
 	if err != nil {
 		l.Error("identityStoreClient error", zap.Error(err))
-		return rs
-	}
-	scimClient, err := c.ssoSCIMClient(ctx)
-	if err != nil {
-		l.Error("scimClient error", zap.Error(err))
-		return rs
 	}
 	if c.ssoEnabled {
+		scimClient, err := c.ssoSCIMClient(ctx)
+		if err != nil {
+			l.Error("scimClient error", zap.Error(err))
+		}
 		rs = append(rs, ssoUserBuilder(c.ssoRegion, ssoAdminClient, identityStoreClient, ix, scimClient))
 		rs = append(rs, ssoGroupBuilder(c.ssoRegion, ssoAdminClient, identityStoreClient, ix))
 	}


### PR DESCRIPTION
Previously if we ran into an error in one of these, we'd return the resource syncers and not sync sso/org-related resources.

Now we return bad resource syncers so we'll correctly error during sync.