### PR TITLE
fix: return empty list of grants if we lack permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,11 @@ jobs:
           BATON_GLOBAL_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           BATON_GLOBAL_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: ./baton-aws && ./baton/baton grants --entitlement='group:arn:aws:iam::737118012813:group/ci-test-group:member' --output-format=json | jq --exit-status '.grants[].principal.id.resource == "arn:aws:iam::737118012813:user/ci-test-user"'
+      - name: Grant already-granted entitlement
+        env:
+          BATON_GLOBAL_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          BATON_GLOBAL_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: ./baton-aws --grant-entitlement 'group:arn:aws:iam::737118012813:group/ci-test-group:member' --grant-principal 'arn:aws:iam::737118012813:user/ci-test-user' --grant-principal-type 'iam_user'
       - name: Revoke grants
         env:
           BATON_GLOBAL_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description

When a user tries to grant membership to an SSO group on AWS to a user already in that group, the connector should not error.

Previously, we'd forward the AWS error claiming there was a conflict. A recent change intercepted that error and fetches the grant data and returns it.

If AWS instance is not configured to allow that "get" call (i.e. `GetGroupMembershipId`), then we have to fall back to returning no grant data and _not_ erroring.