### PR TITLE
Test double-revoking grants.

### DIFF
--- a/pkg/connector/sso_group.go
+++ b/pkg/connector/sso_group.go
@@ -378,7 +378,7 @@ func (g *ssoGroupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (ann
 		return annos, nil
 	}
 
-	l.Error("aws-connector: Failed to delete group membership. Trying to fetch group membership in case grant ID is incorrect", zap.Error(err))
+	l.Info("aws-connector: Failed to delete group membership. Trying to fetch group membership in case grant ID is incorrect", zap.Error(err))
 	groupId, err := ssoGroupIdFromARN(grant.Entitlement.Resource.Id.Resource)
 	if err != nil {
 		return annos, err

--- a/test/grant-revoke.sh
+++ b/test/grant-revoke.sh
@@ -31,7 +31,10 @@ $BATON_AWS --grant-entitlement="$BATON_ENTITLEMENT" --grant-principal="$BATON_PR
 # Get grant ID
 BATON_GRANT=$($BATON grants --entitlement="$BATON_ENTITLEMENT" --output-format=json | jq --raw-output --exit-status ".grants[] | select( .principal.id.resource == \"$BATON_PRINCIPAL\" ).grant.id")
 
-# Revoke grants
+# Revoke grant
+$BATON_AWS --revoke-grant="$BATON_GRANT"
+
+# Revoke already-revoked grant
 $BATON_AWS --revoke-grant="$BATON_GRANT"
 
 # Check grant was revoked


### PR DESCRIPTION
I had to test this manually by commenting out the happy path for revoking (since I always had a correct grant ID). It successfully revokes and handles the case of the user not being in the group (which means the grant was already revoked earlier).