### PR TITLE
[BB-1222] fix assume role twice

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -193,8 +193,6 @@ func New(ctx context.Context, config Config) (*AWS, error) {
 		return nil, fmt.Errorf("aws connector: config load failure: %w", err)
 	}
 
-	awsClientFactory := NewAWSClientFactory(config, baseConfig.Copy(), httpClient)
-
 	rv := &AWS{
 		useAssumeRole:           config.UseAssumeRole,
 		orgsEnabled:             config.GlobalAwsOrgsEnabled,
@@ -216,8 +214,9 @@ func New(ctx context.Context, config Config) (*AWS, error) {
 		_callingConfig:          map[string]awsSdk.Config{},
 		_callingConfigError:     map[string]error{},
 		syncSecrets:             config.SyncSecrets,
-		awsClientFactory:        awsClientFactory,
 	}
+
+	rv.awsClientFactory = NewAWSClientFactory(config, rv, httpClient)
 
 	if rv.ssoEnabled && !rv.orgsEnabled {
 		return nil, fmt.Errorf("aws-connector: SSO Support requires Org support to also be enabled. Please enable both")
@@ -368,7 +367,7 @@ func (c *AWS) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSy
 	}
 
 	if c.orgsEnabled && !c.ssoEnabled {
-		rs = append(rs, accountIAMBuilder(c.orgClient, c.awsClientFactory))
+		rs = append(rs, accountIAMBuilder(c.orgClient, c.awsClientFactory, c))
 	}
 
 	if c.orgsEnabled && c.ssoEnabled {


### PR DESCRIPTION
When `assume-role` is active, we need to assume the role twice to access the child accounts

This change will request an additional permission for the role

```json5
{
    "Effect": "Allow",
    "Action": "sts:AssumeRole",
    "Resource": "arn:aws:iam::*:role/OrganizationAccountAccessRole"
}
```