### PR TITLE
Handle account grant already revoked

### DIFF
--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -441,6 +441,12 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 	complete, err := o.checkDeleteAccountAssignmentStatus(ctx, l, deleteOut.AccountAssignmentDeletionStatus)
 	if err != nil {
+		if strings.Contains(err.Error(), "Received a 404 status error") {
+			l.Info("aws-connector: Grant already revoked.")
+			annos.Append(&v2.GrantAlreadyRevoked{})
+			return annos, nil
+		}
+
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
 			l.Info("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))


### PR DESCRIPTION
Grant already revoked when calling `DeleteAccountAssignment`.  `DescribeAccountAssignmentDeletionStatus` returns:
```
{
  "AccountAssignmentDeletionStatus": {
    "CreatedDate": "2025-09-05T19:38:33.827Z",
    "FailureReason": "Received a 404 status error: EntitlementItem doesn't exist with the given entitlement key EntitlementKey{accessorId=AccessorId{value=ffffffff-ffff-ffff-ffff-ffffffffffff}, resourceId=ResourceId{value=999999999999}, auxiliaryResourceId=AuxiliaryResourceId{value=arn:aws:sso:::permissionSet/ssoins-ffffffffffffffff/ps-cccccccccccccccc}, containerId=ContainerId{value=arn:aws:sso:::instance/ssoins-ffffffffffffffff}}",
    ...
  },
  "ResultMetadata": {}
} 
```