### PR TITLE
[BB-1449] Improve account assignment handling by adding account status verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,15 +58,15 @@ jobs:
         uses: ConductorOne/github-workflows/actions/sync-test@v2
         with:
           connector: ./baton-aws
-          baton-entitlement: 'group:arn:aws:iam::737118012813:group/ci-test-group:member'
-          baton-principal: 'arn:aws:iam::737118012813:user/ci-test-user'
+          baton-entitlement: ${{ vars.BATON_IAM_ENTITLEMENT}}
+          baton-principal: ${{ vars.BATON_IAM_PRINCIPAL}}
           baton-principal-type: 'iam_user'
       - name: Test grant/revoking SSO entitlements
         uses: ConductorOne/github-workflows/actions/sync-test@v2
         with:
           connector: ./baton-aws
-          baton-entitlement: 'sso_group:arn:aws:identitystore:us-east-1::d-90679d1878/group/9458d408-40b1-709f-4f45-92be754928e5:member'
-          baton-principal: 'arn:aws:identitystore:us-east-1::d-90679d1878/user/54982488-f0d1-70c1-1dd5-6db47f7add45'
+          baton-entitlement: ${{ vars.BATON_SSO_ENTITLEMENT}}
+          baton-principal: ${{ vars.BATON_SSO_PRINCIPAL}}
           baton-principal-type: 'sso_user'
       - name: Test IAM user provisioning and deprovisioning
         uses: ConductorOne/github-workflows/actions/account-provisioning@v3

--- a/README.md
+++ b/README.md
@@ -236,6 +236,17 @@ _These policies have comments prefixed with // that need to be removed before us
       "Resource": "*",
       // Enable provisioning of SSO Users directly to permission sets in accounts
       "Sid": "SSOUserToAccountPermissionSetProvisioning"
+    },
+    {
+      "Action": [
+        "organizations:DescribeAccount"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      // Recommended: Enables proactive validation of account status before creating assignments.
+      // Without this, the connector will attempt assignments and may get unclear ConflictException errors
+      // for suspended accounts. This permission provides clearer error messages.
+      "Sid": "AccountStatusValidationForProvisioning"
     }
   ],
   "Version": "2012-10-17"

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -260,13 +260,12 @@ func (o *accountResourceType) verifyAccountStatus(ctx context.Context, accountID
 		var accessDeniedErr *types.AccessDeniedException
 		switch {
 		case errors.As(err, &accessDeniedErr):
-			// we don't have permissions to verify: warn but continue (backward compatibility)
+			// we don't have permissions to verify: debug but continue (backward compatibility)
 			// this maintains backward compatibility with clients that don't have the permission
 			// if the account is suspended, AWS will return ConflictException that we handle later
 			l := ctxzap.Extract(ctx).With(zap.String("account_id", accountID))
-			l.Warn("aws-connector: Cannot verify account status (missing organizations:DescribeAccount permission). " +
-				fmt.Sprintf("Proceeding with assignment %s. If account is suspended, this will fail with ConflictException. ", operation) +
-				"Consider adding organizations:DescribeAccount to your IAM policy for better error messages.")
+			l.Debug("aws-connector: Cannot verify account status (missing organizations:DescribeAccount permission). Proceeding with assignment. If account is suspended, this will fail with ConflictException. Consider adding organizations:DescribeAccount to your IAM policy for better error messages.",
+				zap.String("operation", operation))
 			return true, nil
 		default:
 			// other errors: fail
@@ -359,8 +358,8 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 	if err != nil {
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
-			// we don't have permissions to verify: warn but assume complete (backward compatibility)
-			l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment creation is complete.", zap.Error(err))
+			// we don't have permissions to verify: debug but assume complete (backward compatibility)
+			l.Debug("aws-connector: access denied while attempting to check status. Assuming account assignment creation is complete.", zap.Error(err))
 			complete = true
 		} else {
 			return nil, err
@@ -383,8 +382,8 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		if err != nil {
 			var ae *awsSsoAdminTypes.AccessDeniedException
 			if errors.As(err, &ae) {
-				// we don't have permissions to verify: warn but assume complete (backward compatibility)
-				l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment creation is complete.", zap.Error(err))
+				// we don't have permissions to verify: debug but assume complete (backward compatibility)
+				l.Debug("aws-connector: access denied while attempting to check status. Assuming account assignment creation is complete.", zap.Error(err))
 				complete = true
 			} else {
 				return nil, err
@@ -533,8 +532,8 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
-			// we don't have permissions to verify: warn but assume complete (backward compatibility)
-			l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))
+			// we don't have permissions to verify: debug but assume complete (backward compatibility)
+			l.Debug("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))
 			complete = true
 		} else {
 			return nil, err
@@ -563,8 +562,8 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 			var ae *awsSsoAdminTypes.AccessDeniedException
 			if errors.As(err, &ae) {
-				// we don't have permissions to verify: warn but assume complete (backward compatibility)
-				l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))
+				// we don't have permissions to verify: debug but assume complete (backward compatibility)
+				l.Debug("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))
 				complete = true
 			} else {
 				return nil, err

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -384,10 +384,7 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		if err != nil {
 			var ae *awsSsoAdminTypes.AccessDeniedException
 			if errors.As(err, &ae) {
-				// we couldn't verify, but we continue trying until the timeout
-				l.Warn("aws-connector: access denied while checking status, will retry", zap.Error(err))
-				complete = false
-				continue
+				return nil, fmt.Errorf("aws-connector: access denied while checking account assignment creation status. Missing required permissions: %w", err)
 			}
 			// other errors: fail
 			return nil, err
@@ -568,10 +565,7 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 			var ae *awsSsoAdminTypes.AccessDeniedException
 			if errors.As(err, &ae) {
-				// we couldn't verify, but we continue trying until the timeout
-				l.Warn("aws-connector: access denied while checking status, will retry", zap.Error(err))
-				complete = false
-				continue
+				return nil, fmt.Errorf("aws-connector: access denied while checking account assignment deletion status. Missing required permissions: %w", err)
 			}
 			return nil, err
 		}

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -357,9 +357,12 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 	if err != nil {
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
-			return nil, fmt.Errorf("aws-connector: access denied while checking account assignment creation status. Missing required permissions: %w", err)
+			// we don't have permissions to verify: warn but assume complete (backward compatibility)
+			l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment creation is complete.", zap.Error(err))
+			complete = true
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, AccountAssignmentMaxWaitDuration)
@@ -378,10 +381,12 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		if err != nil {
 			var ae *awsSsoAdminTypes.AccessDeniedException
 			if errors.As(err, &ae) {
-				return nil, fmt.Errorf("aws-connector: access denied while checking account assignment creation status. Missing required permissions: %w", err)
+				// we don't have permissions to verify: warn but assume complete (backward compatibility)
+				l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment creation is complete.", zap.Error(err))
+				complete = true
+			} else {
+				return nil, err
 			}
-			// other errors: fail
-			return nil, err
 		}
 	}
 
@@ -526,9 +531,12 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
-			return nil, fmt.Errorf("aws-connector: access denied while checking account assignment deletion status. Missing required permissions: %w", err)
+			// we don't have permissions to verify: warn but assume complete (backward compatibility)
+			l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))
+			complete = true
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, AccountAssignmentMaxWaitDuration)
@@ -553,9 +561,12 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 			var ae *awsSsoAdminTypes.AccessDeniedException
 			if errors.As(err, &ae) {
-				return nil, fmt.Errorf("aws-connector: access denied while checking account assignment deletion status. Missing required permissions: %w", err)
+				// we don't have permissions to verify: warn but assume complete (backward compatibility)
+				l.Warn("aws-connector: access denied while attempting to check status. Assuming account assignment deletion is complete.", zap.Error(err))
+				complete = true
+			} else {
+				return nil, err
 			}
-			return nil, err
 		}
 	}
 

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -264,7 +264,9 @@ func (o *accountResourceType) verifyAccountStatus(ctx context.Context, accountID
 			// this maintains backward compatibility with clients that don't have the permission
 			// if the account is suspended, AWS will return ConflictException that we handle later
 			l := ctxzap.Extract(ctx).With(zap.String("account_id", accountID))
-			l.Debug("aws-connector: Cannot verify account status (missing organizations:DescribeAccount permission). Proceeding with assignment. If account is suspended, this will fail with ConflictException. Consider adding organizations:DescribeAccount to your IAM policy for better error messages.",
+			l.Debug("aws-connector: Cannot verify account status (missing organizations:DescribeAccount permission). "+
+				"Proceeding with assignment. If account is suspended, this will fail with ConflictException. "+
+				"Consider adding organizations:DescribeAccount to your IAM policy for better error messages.",
 				zap.String("operation", operation))
 			return true, nil
 		default:

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -16,6 +16,8 @@ import (
 	"github.com/conductorone/baton-aws/pkg/connector/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -272,7 +274,7 @@ func (o *accountResourceType) verifyAccountStatus(ctx context.Context, accountID
 		}
 	}
 	if descOut.Account == nil {
-		return false, fmt.Errorf("aws-connector: DescribeAccount returned nil account for %s", accountID)
+		return false, status.Errorf(codes.NotFound, "aws-connector: DescribeAccount returned nil account for %s", accountID)
 	}
 	if descOut.Account.Status != types.AccountStatusActive {
 		// if we could verify and the account is not active, fail

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -357,15 +357,9 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 	if err != nil {
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
-			// we couldn't verify the status, but we already started the operation
-			// in this case, we can't assume success - it could be in progress or have failed
-			// we continue retrying until timeout
-			l.Warn("aws-connector: access denied while attempting to check status. Cannot verify if account assignment was created. Operation may still be in progress.", zap.Error(err))
-			// we don't assume complete, but we don't fail - we let the timeout handle this
-			complete = false
-		} else {
-			return nil, err
+			return nil, fmt.Errorf("aws-connector: access denied while checking account assignment creation status. Missing required permissions: %w", err)
 		}
+		return nil, err
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, AccountAssignmentMaxWaitDuration)
@@ -532,15 +526,9 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 
 		var ae *awsSsoAdminTypes.AccessDeniedException
 		if errors.As(err, &ae) {
-			// we couldn't verify the status, but we already started the operation
-			// in this case, we can't assume success - it could be in progress or have failed
-			// we continue retrying until timeout
-			l.Warn("aws-connector: access denied while attempting to check status. Cannot verify if account assignment deletion was completed. Operation may still be in progress.", zap.Error(err))
-			// we don't assume complete, but we don't fail - we let the timeout handle this
-			complete = false
-		} else {
-			return nil, err
+			return nil, fmt.Errorf("aws-connector: access denied while checking account assignment deletion status. Missing required permissions: %w", err)
 		}
+		return nil, err
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, AccountAssignmentMaxWaitDuration)

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -265,7 +265,7 @@ func (o *accountResourceType) verifyAccountStatus(ctx context.Context, accountID
 			// if the account is suspended, AWS will return ConflictException that we handle later
 			l := ctxzap.Extract(ctx).With(zap.String("account_id", accountID))
 			l.Debug("aws-connector: Cannot verify account status (missing organizations:DescribeAccount permission). "+
-				"Proceeding with assignment. If account is suspended, this will fail with ConflictException. "+
+				"Proceeding with the operation. If account is suspended, this will fail with ConflictException. "+
 				"Consider adding organizations:DescribeAccount to your IAM policy for better error messages.",
 				zap.String("operation", operation))
 			return true, nil

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -296,6 +296,8 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 			// other errors: fail
 			return nil, fmt.Errorf("aws-connector: DescribeAccount failed: %w", err)
 		}
+	} else if descOut.Account == nil {
+		return nil, fmt.Errorf("aws-connector: DescribeAccount returned nil account for %s", binding.AccountID)
 	} else if descOut.Account.Status != types.AccountStatusActive {
 		// if we could verify and the account is not active, fail
 		return nil, fmt.Errorf("aws-connector: account %s is not active, status: %s", binding.AccountID, descOut.Account.Status)
@@ -487,6 +489,8 @@ func (o *accountResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 			// other errors: fail
 			return nil, fmt.Errorf("aws-connector: DescribeAccount failed: %w", err)
 		}
+	} else if descOut.Account == nil {
+		return nil, fmt.Errorf("aws-connector: DescribeAccount returned nil account for %s", binding.AccountID)
 	} else if descOut.Account.Status != types.AccountStatusActive {
 		// if we could verify and the account is not active, fail
 		return nil, fmt.Errorf("aws-connector: account %s is not active, status: %s", binding.AccountID, descOut.Account.Status)

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -155,18 +155,6 @@ func (o *AWS) getCallingConfig(ctx context.Context, region string) (awsSdk.Confi
 				return awsSdk.Config{}, fmt.Errorf("aws-connector: internal binding error")
 			}
 
-			// if globalRoleARN and roleARN are the same, we've already assumed the target role
-			// skip the second assumption and use the binding credentials directly
-			if o.globalRoleARN == o.roleARN {
-				callingConfig := awsSdk.Config{
-					HTTPClient:   o.baseClient,
-					Region:       region,
-					DefaultsMode: awsSdk.DefaultsModeInRegion,
-					Credentials:  bindingCreds,
-				}
-				return callingConfig, nil
-			}
-
 			// ok, now we have a working binding credentials.... lets go.
 			stsConfig := o.baseConfig.Copy()
 			stsConfig.Credentials = bindingCreds


### PR DESCRIPTION
DOC: https://conductorone.atlassian.net/wiki/spaces/~71202071336165eb264ed294c4e93f1fb25f01/pages/2779086859/AWS+connector+error+during+account+assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verify account status before granting or revoking permissions to avoid acting on suspended or non-active accounts.
  * Improved, contextual error messages for account operation failures, including guidance when verification wasn’t possible due to permissions.
  * Allow operations to proceed with explanatory messages when account verification is denied (backward-compatible behavior).
  * Clarified timeout and retry messaging related to account verification and permission issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->