### PR TITLE
[CXP-15] Hide sync-sso-user-last-login flag temporarily

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -209,12 +209,6 @@
       "stringField": {
         "defaultValue": "OrganizationAccountAccessRole"
       }
-    },
-    {
-      "name": "sync-sso-user-last-login",
-      "displayName": "Sync SSO User Last Login",
-      "description": "Enable fetching last login time for SSO users from CloudTrail (requires cloudtrail:LookupEvents permission)",
-      "boolField": {}
     }
   ],
   "constraints": [

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,6 +114,7 @@ var (
 		field.WithDisplayName("Sync SSO User Last Login"),
 		field.WithDescription("Enable fetching last login time for SSO users from CloudTrail (requires cloudtrail:LookupEvents permission)"),
 		field.WithDefaultValue(false),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 


### PR DESCRIPTION
## Summary
- Set `ExportTargetCLIOnly` on the `sync-sso-user-last-login` field so it is excluded from `config_schema.json` and not surfaced in the GUI while the feature is still incomplete.
- Regenerated `config_schema.json` to reflect the change.
- The flag still works for operators running the binary directly; this only hides it from the tenant-facing config schema.

## Test plan
- [ ] `make build && ./dist/*/baton-aws config | jq '.fields[].name'` does not list `sync-sso-user-last-login`
- [ ] CI `capabilities_and_config` workflow regenerates `config_schema.json` matching this commit