### PR TITLE
feat: scaffold Bonbon (AWS Account Access Manager) connector path

### DIFF
--- a/docs/bonbon.md
+++ b/docs/bonbon.md
@@ -1,0 +1,88 @@
+# AWS Account Access Manager (Bonbon)
+
+> Private preview. Scaffold only. Names, regions, and error semantics may move before GA.
+
+`baton-aws` ships an opt-in connector path for AWS Account Access Manager —
+codename **Bonbon** — alongside the existing IAM / Organizations / IdC syncs.
+The service id is `account-access` (`account-access-preview.amazonaws.com`),
+API version `2018-05-10`, REST/JSON, SigV4-signed.
+
+## Resource types
+
+| Resource type        | Trait       | Description                                                                |
+|----------------------|-------------|----------------------------------------------------------------------------|
+| `bonbon_application` | `TRAIT_APP` | One per Bonbon Application discovered via `ListApplications`.              |
+| `bonbon_role`        | `TRAIT_ROLE`| One per distinct target IAM Role ARN observed across `ListEntitlements`.   |
+
+Grants on `bonbon_role` represent `PrincipalRoleEntitlement` bindings — IdC
+user or group → IAM role. Provisioning maps to `CreateEntitlement` /
+`DeleteEntitlement`.
+
+The connector does **not** emit `bonbon_user` / `bonbon_group` resources:
+those IdC principals are already owned by `sso_user` / `sso_group` from the
+existing baton-aws SSO sync path. Bonbon grants reference those resources by
+ID via C1's cross-resource-type graph.
+
+## Required configuration
+
+| Flag                              | Default     | Notes                                                                                              |
+|-----------------------------------|-------------|----------------------------------------------------------------------------------------------------|
+| `--global-bonbon-enabled`         | `false`     | Master gate. Connector is dormant when false.                                                      |
+| `--global-bonbon-region`          | `us-east-1` | Must be `us-east-1` or `us-west-2`; outside set rejected at connector init.                         |
+| `--global-bonbon-application-arn` | _(empty)_   | Optional. Scope the sync to a single Bonbon Application ARN.                                       |
+| `--global-bonbon-base-url`        | _(empty)_   | Override the AWS endpoint. Used only by the integration testserver.                                |
+
+The connector reuses the existing `baton-aws` AWS-credential chain
+(`--use-assume` / `--global-role-arn` / `--role-arn` / `--external-id`), so a
+tenant already onboarded for `baton-aws` does not need new auth wiring.
+
+## Required IAM permissions
+
+Attach to the identity that `baton-aws` assumes into the customer account:
+
+```
+account-access:ListApplications
+account-access:GetApplication
+account-access:ListEntitlements
+account-access:CreateEntitlement
+account-access:DeleteEntitlement
+account-access:ListTagsForResource
+```
+
+## Required role trust policy
+
+Every IAM role that should be grantable via Bonbon must trust the
+`account-access-preview.amazonaws.com` service principal:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "Bonbon",
+    "Effect": "Allow",
+    "Principal": {"Service": ["account-access-preview.amazonaws.com"]},
+    "Action": ["sts:AssumeRole", "sts:SetContext"]
+  }]
+}
+```
+
+`CreateEntitlement` returns a `ValidationException` against roles missing
+this — the connector decorates that error with an inline hint.
+
+## Manual smoke list (private preview)
+
+A real Bonbon-enabled account is required to verify the SigV4 path. Without
+one the testserver-driven integration tests are the only signal.
+
+1. `Validate()` against an account in `us-east-1` with Bonbon enabled.
+2. `CreateEntitlement` against a real IdC user + IAM role with the trust
+   policy attached. Verify the user can assume.
+3. `DeleteEntitlement` and verify it disappears from `ListEntitlements`.
+
+## Rollout
+
+- Default off via `--global-bonbon-enabled=false`. Per-tenant opt-in flips
+  the flag.
+- All `bonbon_*` resource types are annotated `&v2.OptInRequired{}` so the
+  C1 product surface treats them as opt-in regardless of the binary's
+  default.

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -18,6 +18,10 @@ type Aws struct {
 	SyncSecrets bool `mapstructure:"sync-secrets"`
 	IamAssumeRoleName string `mapstructure:"iam-assume-role-name"`
 	SyncSsoUserLastLogin bool `mapstructure:"sync-sso-user-last-login"`
+	GlobalBonbonEnabled bool `mapstructure:"global-bonbon-enabled"`
+	GlobalBonbonRegion string `mapstructure:"global-bonbon-region"`
+	GlobalBonbonApplicationArn string `mapstructure:"global-bonbon-application-arn"`
+	GlobalBonbonBaseUrl string `mapstructure:"global-bonbon-base-url"`
 }
 
 func (c *Aws) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,6 +115,31 @@ var (
 		field.WithDescription("Enable fetching last login time for SSO users from CloudTrail (requires cloudtrail:LookupEvents permission)"),
 		field.WithDefaultValue(false),
 	)
+
+	GlobalBonbonEnabledField = field.BoolField(
+		"global-bonbon-enabled",
+		field.WithDisplayName("Enable AWS Account Access Manager (Bonbon)"),
+		field.WithDescription("Enable support for AWS Account Access Manager (codename: Bonbon) — private preview"),
+		field.WithDefaultValue(false),
+	)
+	GlobalBonbonRegionField = field.SelectField(
+		"global-bonbon-region",
+		[]string{"us-east-1", "us-west-2"},
+		field.WithDisplayName("Region for AWS Account Access Manager"),
+		field.WithDescription("Region for the AWS Account Access Manager API. Private preview is us-east-1 / us-west-2 only."),
+		field.WithDefaultValue("us-east-1"),
+	)
+	GlobalBonbonApplicationArnField = field.StringField(
+		"global-bonbon-application-arn",
+		field.WithDisplayName("Bonbon Application ARN"),
+		field.WithDescription("Optional. Scope the sync to a single Bonbon Application ARN. If unset, all applications in the account are synced."),
+	)
+	GlobalBonbonBaseURLField = field.StringField(
+		"global-bonbon-base-url",
+		field.WithDisplayName("Bonbon API base URL override"),
+		field.WithDescription("Optional. Override the AWS Account Access Manager endpoint. Used by integration tests; leave empty in production."),
+		field.WithExportTarget(field.ExportTargetOps),
+	)
 )
 
 //go:generate go run ./gen
@@ -134,6 +159,10 @@ var Config = field.NewConfiguration(
 		SyncSecrets,
 		IamAssumeRoleName,
 		SyncSSOUserLastLogin,
+		GlobalBonbonEnabledField,
+		GlobalBonbonRegionField,
+		GlobalBonbonApplicationArnField,
+		GlobalBonbonBaseURLField,
 	},
 	field.WithConstraints(
 		field.FieldsDependentOn(

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -122,6 +122,26 @@ func TestConfigs(t *testing.T) {
 				true,
 				"empty",
 			},
+			{
+				"--global-bonbon-enabled",
+				true,
+				"bonbon: enabled flag accepted",
+			},
+			{
+				"--global-bonbon-enabled --global-bonbon-region us-east-1",
+				true,
+				"bonbon: us-east-1 is a supported preview region",
+			},
+			{
+				"--global-bonbon-enabled --global-bonbon-region us-west-2",
+				true,
+				"bonbon: us-west-2 is a supported preview region",
+			},
+			{
+				"--global-bonbon-enabled --global-bonbon-region eu-central-1",
+				false,
+				"bonbon: eu-central-1 is rejected outside private preview",
+			},
 		},
 	)
 }

--- a/pkg/connector/bonbon/application.go
+++ b/pkg/connector/bonbon/application.go
@@ -1,0 +1,131 @@
+package bonbon
+
+import (
+	"context"
+	"fmt"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+type applicationResourceType struct {
+	client *Client
+
+	// scopedArn pins the connector to a single Bonbon Application when the
+	// operator passes --global-bonbon-application-arn. Empty means list all.
+	scopedArn string
+}
+
+func ApplicationBuilder(c *Client, scopedArn string) *applicationResourceType {
+	return &applicationResourceType{client: c, scopedArn: scopedArn}
+}
+
+func (o *applicationResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return ResourceTypeApplication
+}
+
+func (o *applicationResourceType) List(ctx context.Context, _ *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
+	if o.scopedArn != "" {
+		return o.singleApplication(ctx, opts)
+	}
+
+	bag := &pagination.Bag{}
+	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
+		return nil, nil, err
+	}
+	if bag.Current() == nil {
+		bag.Push(pagination.PageState{ResourceTypeID: ResourceTypeApplicationId})
+	}
+
+	req := &ListApplicationsRequest{}
+	if bag.PageToken() != "" {
+		req.NextToken = bag.PageToken()
+	}
+
+	listResp, err := o.client.ListApplications(ctx, req)
+	if err != nil {
+		return nil, nil, WrapForRetry(fmt.Errorf("bonbon: ListApplications: %w", err))
+	}
+
+	out := make([]*v2.Resource, 0, len(listResp.Applications))
+	arns := make([]string, 0, len(listResp.Applications))
+	for _, summary := range listResp.Applications {
+		res, err := o.hydrate(ctx, summary.ApplicationArn)
+		if err != nil {
+			return nil, nil, err
+		}
+		out = append(out, res)
+		arns = append(arns, summary.ApplicationArn)
+	}
+
+	// Persist the discovered set so bonbon_role.List can iterate it.
+	prior, err := readApplications(ctx, opts.Session)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := writeApplications(ctx, opts.Session, append(prior, arns...)); err != nil {
+		return nil, nil, err
+	}
+
+	if listResp.NextToken != "" {
+		token, err := bag.NextToken(listResp.NextToken)
+		if err != nil {
+			return out, nil, err
+		}
+		return out, &resourceSdk.SyncOpResults{NextPageToken: token}, nil
+	}
+	return out, nil, nil
+}
+
+func (o *applicationResourceType) singleApplication(ctx context.Context, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
+	res, err := o.hydrate(ctx, o.scopedArn)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := writeApplications(ctx, opts.Session, []string{o.scopedArn}); err != nil {
+		return nil, nil, err
+	}
+	return []*v2.Resource{res}, nil, nil
+}
+
+func (o *applicationResourceType) hydrate(ctx context.Context, applicationArn string) (*v2.Resource, error) {
+	app, err := o.client.GetApplication(ctx, applicationArn)
+	if err != nil {
+		return nil, WrapForRetry(fmt.Errorf("bonbon: GetApplication: %w", err))
+	}
+
+	profile := map[string]interface{}{
+		"bonbon_application_arn": app.ApplicationArn,
+		"bonbon_tenant_id":       app.TenantId,
+		"bonbon_status":          app.Status,
+	}
+	if app.IdentitySource != nil && app.IdentitySource.IdentityCenter != nil {
+		profile["identity_center_instance_arn"] = app.IdentitySource.IdentityCenter.InstanceArn
+	}
+	for _, tag := range app.Tags {
+		profile["tag_"+tag.Key] = tag.Value
+	}
+
+	displayName := app.ApplicationArn
+	if app.TenantId != "" {
+		displayName = "Bonbon: " + app.TenantId
+	}
+
+	annos := &v2.V1Identifier{Id: app.ApplicationArn}
+	return resourceSdk.NewAppResource(
+		displayName,
+		ResourceTypeApplication,
+		app.ApplicationArn,
+		[]resourceSdk.AppTraitOption{resourceSdk.WithAppProfile(profile)},
+		resourceSdk.WithAnnotation(annos),
+	)
+}
+
+func (o *applicationResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *applicationResourceType) Grants(_ context.Context, _ *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}

--- a/pkg/connector/bonbon/client.go
+++ b/pkg/connector/bonbon/client.go
@@ -1,0 +1,215 @@
+package bonbon
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+const emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+// Client speaks to the AWS Account Access Manager REST/JSON service. SigV4
+// signing pulls credentials from the supplied awsSdk.Config — the caller is
+// responsible for wiring AssumeRole / external-id / static-creds via the
+// existing baton-aws AWSClientFactory before constructing the Client.
+type Client struct {
+	httpClient *http.Client
+	cfg        awsSdk.Config
+	signer     *v4.Signer
+	region     string
+	endpoint   string
+	now        func() time.Time
+}
+
+type ClientOption func(*Client)
+
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *Client) {
+		if hc != nil {
+			c.httpClient = hc
+		}
+	}
+}
+
+// WithEndpoint overrides the default `https://account-access.<region>.amazonaws.com`
+// — primarily for pointing the connector at a testserver during integration tests.
+func WithEndpoint(endpoint string) ClientOption {
+	return func(c *Client) {
+		if endpoint != "" {
+			c.endpoint = endpoint
+		}
+	}
+}
+
+func WithClock(now func() time.Time) ClientOption {
+	return func(c *Client) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+func NewClient(cfg awsSdk.Config, region string, opts ...ClientOption) *Client {
+	c := &Client{
+		httpClient: http.DefaultClient,
+		cfg:        cfg,
+		signer:     v4.NewSigner(),
+		region:     region,
+		endpoint:   fmt.Sprintf("https://"+DefaultHostFmt, region),
+		now:        time.Now,
+	}
+	if cfg.HTTPClient != nil {
+		if hc, ok := cfg.HTTPClient.(*http.Client); ok {
+			c.httpClient = hc
+		}
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *Client) Region() string   { return c.region }
+func (c *Client) Endpoint() string { return c.endpoint }
+
+func (c *Client) do(ctx context.Context, method, path string, query url.Values, in any, out any) error {
+	var body []byte
+	if in != nil {
+		var err error
+		body, err = json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("bonbon: encode request: %w", err)
+		}
+	}
+
+	u := c.endpoint + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("bonbon: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	payloadHash := emptyPayloadHash
+	if len(body) > 0 {
+		sum := sha256.Sum256(body)
+		payloadHash = hex.EncodeToString(sum[:])
+	}
+
+	if c.cfg.Credentials != nil {
+		creds, err := c.cfg.Credentials.Retrieve(ctx)
+		if err != nil {
+			return fmt.Errorf("bonbon: retrieve credentials: %w", err)
+		}
+		if err := c.signer.SignHTTP(ctx, creds, req, payloadHash, SigningName, c.region, c.now()); err != nil {
+			return fmt.Errorf("bonbon: sign request: %w", err)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("bonbon: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("bonbon: read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return parseAPIError(resp, respBody)
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("bonbon: decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) ListApplications(ctx context.Context, in *ListApplicationsRequest) (*ListApplicationsResponse, error) {
+	if in == nil {
+		in = &ListApplicationsRequest{}
+	}
+	out := &ListApplicationsResponse{}
+	if err := c.do(ctx, http.MethodPost, "/applications-list", nil, in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) GetApplication(ctx context.Context, applicationArn string) (*GetApplicationResponse, error) {
+	out := &GetApplicationResponse{}
+	path := "/applications/" + url.PathEscape(applicationArn)
+	if err := c.do(ctx, http.MethodGet, path, nil, nil, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ListTagsForResource(ctx context.Context, resourceArn string) (*ListTagsForResourceResponse, error) {
+	out := &ListTagsForResourceResponse{}
+	path := "/tags/" + url.PathEscape(resourceArn)
+	if err := c.do(ctx, http.MethodGet, path, nil, nil, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ListEntitlements(ctx context.Context, in *ListEntitlementsRequest) (*ListEntitlementsResponse, error) {
+	if in == nil {
+		return nil, fmt.Errorf("bonbon: ListEntitlements requires a request with applicationArn")
+	}
+	out := &ListEntitlementsResponse{}
+	if err := c.do(ctx, http.MethodPost, "/entitlements-list", nil, in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) GetEntitlement(ctx context.Context, applicationArn, entitlementId string) (*GetEntitlementResponse, error) {
+	out := &GetEntitlementResponse{}
+	q := url.Values{}
+	q.Set("applicationArn", applicationArn)
+	path := "/entitlements/" + url.PathEscape(entitlementId)
+	if err := c.do(ctx, http.MethodGet, path, q, nil, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) CreateEntitlement(ctx context.Context, in *CreateEntitlementRequest) (*CreateEntitlementResponse, error) {
+	if in == nil {
+		return nil, fmt.Errorf("bonbon: CreateEntitlement requires a request")
+	}
+	out := &CreateEntitlementResponse{}
+	if err := c.do(ctx, http.MethodPost, "/entitlements", nil, in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) DeleteEntitlement(ctx context.Context, applicationArn, entitlementId string) error {
+	q := url.Values{}
+	q.Set("applicationArn", applicationArn)
+	path := "/entitlements/" + url.PathEscape(entitlementId)
+	return c.do(ctx, http.MethodDelete, path, q, nil, nil)
+}

--- a/pkg/connector/bonbon/connector.go
+++ b/pkg/connector/bonbon/connector.go
@@ -1,0 +1,72 @@
+package bonbon
+
+import (
+	"context"
+	"fmt"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+)
+
+// Config carries the per-sync inputs the Bonbon resource syncers need. SSORegion
+// and IdentityStoreId are required to synthesize the cross-resource-type
+// principal IDs that match what baton-aws's sso_user/sso_group syncers emit;
+// without them, role grants would dangle.
+type Config struct {
+	Region          string
+	ApplicationArn  string
+	BaseURL         string
+	SSORegion       string
+	IdentityStoreId string
+}
+
+// SupportedRegions enumerates the regions Bonbon is currently exposed in
+// during private preview. Operators picking anything outside this set get an
+// explicit error at connector init rather than a 404 mid-sync.
+var SupportedRegions = map[string]struct{}{
+	"us-east-1": {},
+	"us-west-2": {},
+}
+
+func ValidateRegion(region string) error {
+	if region == "" {
+		return fmt.Errorf("bonbon: region is required")
+	}
+	if _, ok := SupportedRegions[region]; !ok {
+		return fmt.Errorf("bonbon: %q is not a supported region (private preview: us-east-1, us-west-2)", region)
+	}
+	return nil
+}
+
+// ResourceSyncers returns the two builders ready to slot into the parent
+// baton-aws Connector's ResourceSyncers slice. Returns nil if cfg.Region is
+// empty so the caller can short-circuit when the bonbon-enabled flag is off.
+func ResourceSyncers(awsCfg awsSdk.Config, cfg Config, opts ...ClientOption) ([]connectorbuilder.ResourceSyncerV2, error) {
+	if err := ValidateRegion(cfg.Region); err != nil {
+		return nil, err
+	}
+	if cfg.BaseURL != "" {
+		opts = append([]ClientOption{WithEndpoint(cfg.BaseURL)}, opts...)
+	}
+	client := NewClient(awsCfg, cfg.Region, opts...)
+
+	return []connectorbuilder.ResourceSyncerV2{
+		ApplicationBuilder(client, cfg.ApplicationArn),
+		RoleBuilder(client, cfg.SSORegion, cfg.IdentityStoreId),
+	}, nil
+}
+
+// DefaultCapabilities returns the resource syncers wired against an empty
+// client. Used by the DefaultCapabilitiesBuilder path so the generated
+// capabilities manifest always lists the Bonbon resource types — even when
+// the connector boots with --global-bonbon-enabled=false.
+func DefaultCapabilities() []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
+		ApplicationBuilder(nil, ""),
+		RoleBuilder(nil, "", ""),
+	}
+}
+
+// Ctx is exported only to silence unused-import lint when the package is
+// vendored without callers invoking the syncer methods directly.
+var _ = context.Background

--- a/pkg/connector/bonbon/connector_test.go
+++ b/pkg/connector/bonbon/connector_test.go
@@ -1,0 +1,177 @@
+package bonbon_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/conductorone/baton-aws/pkg/connector/bonbon"
+	bonbontest "github.com/conductorone/baton-aws/test/bonbon-testserver"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+	"github.com/stretchr/testify/require"
+)
+
+// memSession is a no-frills in-memory SessionStore implementation. The
+// production session store is provided by the sync engine; tests need only
+// the operations bonbon's session.go writes through.
+type memSession struct {
+	data map[string][]byte
+}
+
+func newMemSession() *memSession { return &memSession{data: map[string][]byte{}} }
+
+func (m *memSession) Get(_ context.Context, k string, _ ...sessions.SessionStoreOption) ([]byte, bool, error) {
+	v, ok := m.data[k]
+	return v, ok, nil
+}
+func (m *memSession) GetMany(_ context.Context, keys []string, _ ...sessions.SessionStoreOption) (map[string][]byte, []string, error) {
+	out := map[string][]byte{}
+	var miss []string
+	for _, k := range keys {
+		if v, ok := m.data[k]; ok {
+			out[k] = v
+		} else {
+			miss = append(miss, k)
+		}
+	}
+	return out, miss, nil
+}
+func (m *memSession) Set(_ context.Context, k string, v []byte, _ ...sessions.SessionStoreOption) error {
+	m.data[k] = v
+	return nil
+}
+func (m *memSession) SetMany(_ context.Context, values map[string][]byte, _ ...sessions.SessionStoreOption) error {
+	for k, v := range values {
+		m.data[k] = v
+	}
+	return nil
+}
+func (m *memSession) Delete(_ context.Context, k string, _ ...sessions.SessionStoreOption) error {
+	delete(m.data, k)
+	return nil
+}
+func (m *memSession) Clear(_ context.Context, _ ...sessions.SessionStoreOption) error {
+	m.data = map[string][]byte{}
+	return nil
+}
+func (m *memSession) GetAll(_ context.Context, _ string, _ ...sessions.SessionStoreOption) (map[string][]byte, string, error) {
+	out := map[string][]byte{}
+	for k, v := range m.data {
+		out[k] = v
+	}
+	return out, "", nil
+}
+
+// noAuthCfg pairs with the testserver, which accepts unsigned requests.
+func noAuthCfg() awsSdk.Config { return awsSdk.Config{} }
+
+const (
+	testSSORegion       = "us-east-1"
+	testIdentityStoreId = "d-90679d1878"
+)
+
+func ssoUserARN(userId string) string {
+	return fmt.Sprintf("arn:aws:identitystore:%s::%s/user/%s", testSSORegion, testIdentityStoreId, userId)
+}
+
+func newSyncOpts(s *memSession) resourceSdk.SyncOpAttrs {
+	return resourceSdk.SyncOpAttrs{
+		SyncID:    "test-sync",
+		PageToken: pagination.Token{Token: ""},
+		Session:   s,
+	}
+}
+
+func TestBonbonFullSync(t *testing.T) {
+	ctx := context.Background()
+	srv := bonbontest.New()
+	t.Cleanup(srv.Close)
+
+	client := bonbon.NewClient(noAuthCfg(), "us-east-1", bonbon.WithEndpoint(srv.URL()))
+	appBuilder := bonbon.ApplicationBuilder(client, "")
+	roleBuilder := bonbon.RoleBuilder(client, testSSORegion, testIdentityStoreId)
+	session := newMemSession()
+
+	apps, _, err := appBuilder.List(ctx, nil, newSyncOpts(session))
+	require.NoError(t, err)
+	require.Len(t, apps, 1, "expected one Bonbon application from the testserver")
+	require.Equal(t, bonbon.ResourceTypeApplicationId, apps[0].Id.ResourceType)
+	require.Equal(t, srv.AppArn(), apps[0].Id.Resource)
+
+	roles, _, err := roleBuilder.List(ctx, nil, newSyncOpts(session))
+	require.NoError(t, err)
+	require.Len(t, roles, 2, "expected two distinct target roles across the seed entitlements")
+	roleIDs := map[string]bool{}
+	for _, r := range roles {
+		roleIDs[r.Id.Resource] = true
+	}
+	for _, expected := range bonbontest.TestRoleArns() {
+		require.True(t, roleIDs[expected], "missing role %s", expected)
+	}
+
+	totalGrants := 0
+	for _, r := range roles {
+		grants, _, err := roleBuilder.Grants(ctx, r, newSyncOpts(session))
+		require.NoError(t, err)
+		totalGrants += len(grants)
+		for _, g := range grants {
+			require.NotEmpty(t, g.Id)
+			require.Contains(t,
+				[]string{bonbon.SSOUserResourceTypeId, bonbon.SSOGroupResourceTypeId},
+				g.Principal.Id.ResourceType)
+		}
+	}
+	_, seededEntitlements := srv.Counts()
+	require.Equal(t, seededEntitlements, totalGrants, "every seeded entitlement must produce a grant")
+}
+
+func TestBonbonGrantRevoke(t *testing.T) {
+	ctx := context.Background()
+	srv := bonbontest.New()
+	t.Cleanup(srv.Close)
+	_, initialEntitlements := srv.Counts()
+
+	client := bonbon.NewClient(noAuthCfg(), "us-east-1", bonbon.WithEndpoint(srv.URL()))
+	roleBuilder := bonbon.RoleBuilder(client, testSSORegion, testIdentityStoreId)
+
+	roleRes := &v2.Resource{Id: &v2.ResourceId{ResourceType: bonbon.ResourceTypeRoleId, Resource: bonbontest.TestRoleArns()[0]}}
+	ents, _, err := roleBuilder.Entitlements(ctx, roleRes, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	require.Len(t, ents, 1)
+	roleEnt := ents[0]
+	roleEnt.Resource = roleRes
+
+	newUserId := "99999999-eeee-ffff-aaaa-999999999999"
+	principal := &v2.Resource{Id: &v2.ResourceId{
+		ResourceType: bonbon.SSOUserResourceTypeId,
+		Resource:     ssoUserARN(newUserId),
+	}}
+
+	grants, annos, err := roleBuilder.Grant(ctx, principal, roleEnt)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.NotEmpty(t, grants[0].Id)
+	require.Empty(t, annos, "fresh grant should not be annotated as already-existing")
+
+	_, postCreateEntitlements := srv.Counts()
+	require.Equal(t, initialEntitlements+1, postCreateEntitlements, "expected one new entitlement on the testserver")
+
+	regrants, annos2, err := roleBuilder.Grant(ctx, principal, roleEnt)
+	require.NoError(t, err)
+	require.Len(t, regrants, 1, "idempotent grant should still surface the canonical grant")
+	require.NotEmpty(t, annos2, "duplicate grant should carry the GrantAlreadyExists annotation")
+
+	revokeAnnos, err := roleBuilder.Revoke(ctx, grants[0])
+	require.NoError(t, err)
+	_, postDeleteEntitlements := srv.Counts()
+	require.Equal(t, initialEntitlements, postDeleteEntitlements, "entitlement should be removed after revoke")
+	require.Empty(t, revokeAnnos)
+
+	revokeAnnos2, err := roleBuilder.Revoke(ctx, grants[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, revokeAnnos2, "second revoke should report GrantAlreadyRevoked")
+}

--- a/pkg/connector/bonbon/errors.go
+++ b/pkg/connector/bonbon/errors.go
@@ -1,0 +1,72 @@
+package bonbon
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// APIError is the canonical structured error returned by the AWS
+// Account Access Manager service. Callers extract Type with errors.As to
+// branch on AlreadyCreatedException / ResourceNotFoundException without
+// relying on HTTP status alone — the service-2.json declares the shapes
+// but does not pin status codes for every modeled error.
+type APIError struct {
+	Type       string
+	Message    string
+	StatusCode int
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("bonbon: %s: %s", e.Type, e.Message)
+	}
+	return fmt.Sprintf("bonbon: %s (status %d)", e.Type, e.StatusCode)
+}
+
+func parseAPIError(resp *http.Response, body []byte) *APIError {
+	p := decodeError(body)
+	t := p.Type
+	if t == "" {
+		t = resp.Header.Get("X-Amzn-ErrorType")
+	}
+	if idx := strings.IndexByte(t, ':'); idx >= 0 {
+		t = t[:idx]
+	}
+	if idx := strings.LastIndexByte(t, '#'); idx >= 0 {
+		t = t[idx+1:]
+	}
+	return &APIError{Type: t, Message: p.Message, StatusCode: resp.StatusCode}
+}
+
+func isType(err error, t string) bool {
+	var ae *APIError
+	if !errors.As(err, &ae) {
+		return false
+	}
+	return ae.Type == t
+}
+
+func IsAlreadyCreated(err error) bool   { return isType(err, "AlreadyCreatedException") }
+func IsResourceNotFound(err error) bool { return isType(err, "ResourceNotFoundException") }
+func IsValidation(err error) bool       { return isType(err, "ValidationException") }
+func IsAccessDenied(err error) bool     { return isType(err, "AccessDeniedException") }
+func IsConflict(err error) bool         { return isType(err, "ConflictException") }
+func IsThrottling(err error) bool       { return isType(err, "ThrottlingException") }
+func IsInternalServer(err error) bool   { return isType(err, "InternalServerException") }
+
+// WrapForRetry maps transient service errors to gRPC Unavailable so the
+// baton-sdk sync engine retries them. Permanent errors pass through.
+func WrapForRetry(err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsThrottling(err) || IsInternalServer(err) {
+		return status.Error(codes.Unavailable, err.Error())
+	}
+	return err
+}

--- a/pkg/connector/bonbon/principal.go
+++ b/pkg/connector/bonbon/principal.go
@@ -1,0 +1,44 @@
+package bonbon
+
+import (
+	"fmt"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+const (
+	SSOUserResourceTypeId  = "sso_user"
+	SSOGroupResourceTypeId = "sso_group"
+)
+
+func ssoUserARN(region, identityStoreId, userId string) string {
+	return fmt.Sprintf("arn:aws:identitystore:%s::%s/user/%s", region, identityStoreId, userId)
+}
+
+func ssoGroupARN(region, identityStoreId, groupId string) string {
+	return fmt.Sprintf("arn:aws:identitystore:%s::%s/group/%s", region, identityStoreId, groupId)
+}
+
+// principalResourceID returns the cross-resource-type ID for the IdC user or
+// group referenced by a Bonbon entitlement. Returns nil if the entitlement
+// does not carry a usable principal (e.g. unsupported shape) — caller should
+// skip emitting a grant in that case.
+func principalResourceID(region, identityStoreId string, p Principal) (*v2.ResourceId, error) {
+	if p.IdentityCenter == nil {
+		return nil, nil
+	}
+	switch {
+	case p.IdentityCenter.UserId != "":
+		return resourceSdk.NewResourceID(
+			&v2.ResourceType{Id: SSOUserResourceTypeId},
+			ssoUserARN(region, identityStoreId, p.IdentityCenter.UserId),
+		)
+	case p.IdentityCenter.GroupId != "":
+		return resourceSdk.NewResourceID(
+			&v2.ResourceType{Id: SSOGroupResourceTypeId},
+			ssoGroupARN(region, identityStoreId, p.IdentityCenter.GroupId),
+		)
+	}
+	return nil, nil
+}

--- a/pkg/connector/bonbon/region_test.go
+++ b/pkg/connector/bonbon/region_test.go
@@ -1,0 +1,26 @@
+package bonbon
+
+import "testing"
+
+func TestValidateRegion(t *testing.T) {
+	cases := []struct {
+		name    string
+		region  string
+		wantErr bool
+	}{
+		{name: "us-east-1", region: "us-east-1", wantErr: false},
+		{name: "us-west-2", region: "us-west-2", wantErr: false},
+		{name: "empty", region: "", wantErr: true},
+		{name: "eu-central-1", region: "eu-central-1", wantErr: true},
+		{name: "ap-southeast-1", region: "ap-southeast-1", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRegion(tc.region)
+			gotErr := err != nil
+			if gotErr != tc.wantErr {
+				t.Fatalf("ValidateRegion(%q) err = %v; want error = %v", tc.region, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/connector/bonbon/resource_types.go
+++ b/pkg/connector/bonbon/resource_types.go
@@ -1,0 +1,52 @@
+package bonbon
+
+import (
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+)
+
+const (
+	ResourceTypeApplicationId = "bonbon_application"
+	ResourceTypeRoleId        = "bonbon_role"
+	RoleAssignedEntitlement   = "assigned"
+)
+
+func capabilityPermissions(perms ...string) *v2.CapabilityPermissions {
+	cp := &v2.CapabilityPermissions{}
+	for _, p := range perms {
+		cp.Permissions = append(cp.Permissions, &v2.CapabilityPermission{Permission: p})
+	}
+	return cp
+}
+
+var (
+	ResourceTypeApplication = &v2.ResourceType{
+		Id:          ResourceTypeApplicationId,
+		DisplayName: "Bonbon Application",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP},
+		Annotations: annotations.New(
+			&v2.OptInRequired{},
+			&v2.V1Identifier{Id: ResourceTypeApplicationId},
+			capabilityPermissions(
+				"account-access:ListApplications",
+				"account-access:GetApplication",
+				"account-access:ListTagsForResource",
+			),
+		),
+	}
+
+	ResourceTypeRole = &v2.ResourceType{
+		Id:          ResourceTypeRoleId,
+		DisplayName: "Bonbon Target Role",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
+		Annotations: annotations.New(
+			&v2.OptInRequired{},
+			&v2.V1Identifier{Id: ResourceTypeRoleId},
+			capabilityPermissions(
+				"account-access:ListEntitlements",
+				"account-access:CreateEntitlement",
+				"account-access:DeleteEntitlement",
+			),
+		),
+	}
+)

--- a/pkg/connector/bonbon/role.go
+++ b/pkg/connector/bonbon/role.go
@@ -1,0 +1,402 @@
+package bonbon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	entitlementSdk "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	grantSdk "github.com/conductorone/baton-sdk/pkg/types/grant"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+// roleAssignmentExternalIDPrefix tags grant external IDs so Revoke can recover
+// `applicationArn` + `entitlementId` without a separate session lookup. A grant
+// without this prefix forces a `ListEntitlements` fallback at revoke time.
+const roleAssignmentExternalIDPrefix = "bonbon:"
+
+type roleResourceType struct {
+	client          *Client
+	ssoRegion       string
+	identityStoreId string
+}
+
+func RoleBuilder(c *Client, ssoRegion, identityStoreId string) *roleResourceType {
+	return &roleResourceType{
+		client:          c,
+		ssoRegion:       ssoRegion,
+		identityStoreId: identityStoreId,
+	}
+}
+
+func (o *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return ResourceTypeRole
+}
+
+// loadAllEntitlements walks ListEntitlements across all applications discovered
+// by bonbon_application.List, caching the per-app result on the session so
+// Grants() can avoid re-paginating.
+func (o *roleResourceType) loadAllEntitlements(ctx context.Context, opts resourceSdk.SyncOpAttrs) (map[string][]EntitlementSummary, []string, error) {
+	apps, err := readApplications(ctx, opts.Session)
+	if err != nil {
+		return nil, nil, err
+	}
+	out := make(map[string][]EntitlementSummary, len(apps))
+	for _, appArn := range apps {
+		ents, cached, err := readEntitlements(ctx, opts.Session, appArn)
+		if err != nil {
+			return nil, nil, err
+		}
+		if cached {
+			out[appArn] = ents
+			continue
+		}
+		walked, err := o.walkEntitlements(ctx, appArn)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := writeEntitlements(ctx, opts.Session, appArn, walked); err != nil {
+			return nil, nil, err
+		}
+		out[appArn] = walked
+	}
+	return out, apps, nil
+}
+
+func (o *roleResourceType) walkEntitlements(ctx context.Context, applicationArn string) ([]EntitlementSummary, error) {
+	out := make([]EntitlementSummary, 0)
+	var nextToken string
+	for {
+		resp, err := o.client.ListEntitlements(ctx, &ListEntitlementsRequest{
+			ApplicationArn: applicationArn,
+			Filter:         EntitlementFilter{},
+			NextToken:      nextToken,
+		})
+		if err != nil {
+			return nil, WrapForRetry(fmt.Errorf("bonbon: ListEntitlements: %w", err))
+		}
+		out = append(out, resp.Entitlements...)
+		if resp.NextToken == "" {
+			break
+		}
+		nextToken = resp.NextToken
+	}
+	return out, nil
+}
+
+func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
+	all, _, err := o.loadAllEntitlements(ctx, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	seen := map[string]struct{}{}
+	out := make([]*v2.Resource, 0)
+	for _, ents := range all {
+		for _, e := range ents {
+			if e.PrincipalRole == nil || e.PrincipalRole.RoleArn == "" {
+				continue
+			}
+			roleArn := e.PrincipalRole.RoleArn
+			if _, ok := seen[roleArn]; ok {
+				continue
+			}
+			seen[roleArn] = struct{}{}
+
+			res, err := o.buildRoleResource(roleArn)
+			if err != nil {
+				return nil, nil, err
+			}
+			out = append(out, res)
+		}
+	}
+	return out, nil, nil
+}
+
+func (o *roleResourceType) buildRoleResource(roleArn string) (*v2.Resource, error) {
+	displayName := roleArn
+	if idx := strings.LastIndex(roleArn, "/"); idx >= 0 && idx+1 < len(roleArn) {
+		displayName = roleArn[idx+1:]
+	}
+
+	profile := map[string]interface{}{
+		"bonbon_role_arn": roleArn,
+	}
+	annos := &v2.V1Identifier{Id: roleArn}
+	return resourceSdk.NewRoleResource(
+		displayName,
+		ResourceTypeRole,
+		roleArn,
+		[]resourceSdk.RoleTraitOption{resourceSdk.WithRoleProfile(profile)},
+		resourceSdk.WithAnnotation(annos),
+	)
+}
+
+func (o *roleResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	var annos annotations.Annotations
+	annos.Update(&v2.V1Identifier{Id: fmt.Sprintf("%s:%s", resource.Id.Resource, RoleAssignedEntitlement)})
+
+	ent := entitlementSdk.NewAssignmentEntitlement(
+		resource,
+		RoleAssignedEntitlement,
+		entitlementSdk.WithGrantableTo(
+			&v2.ResourceType{Id: SSOUserResourceTypeId},
+			&v2.ResourceType{Id: SSOGroupResourceTypeId},
+		),
+	)
+	ent.Description = fmt.Sprintf("Assigned %s via Bonbon", resource.DisplayName)
+	ent.Annotations = annos
+	ent.DisplayName = fmt.Sprintf("%s Assigned", resource.DisplayName)
+	return []*v2.Entitlement{ent}, nil, nil
+}
+
+func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	roleArn := resource.Id.Resource
+	all, _, err := o.loadAllEntitlements(ctx, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := make([]*v2.Grant, 0)
+	for appArn, ents := range all {
+		for _, e := range ents {
+			if e.PrincipalRole == nil || e.PrincipalRole.RoleArn != roleArn {
+				continue
+			}
+			principalId, err := principalResourceID(o.ssoRegion, o.identityStoreId, e.PrincipalRole.Principal)
+			if err != nil {
+				return nil, nil, err
+			}
+			if principalId == nil {
+				continue
+			}
+			g := grantSdk.NewGrant(resource, RoleAssignedEntitlement, principalId)
+			g.Id = encodeGrantExternalID(appArn, e.EntitlementId)
+			out = append(out, g)
+		}
+	}
+	return out, nil, nil
+}
+
+// Grant implements ResourceProvisionerV2. The Bonbon CreateEntitlement API is
+// idempotent on the service side; we still treat AlreadyCreatedException as
+// success and reconstruct the canonical external ID via a follow-up list pass.
+func (o *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	roleArn := entitlement.Resource.Id.Resource
+
+	apps, err := o.applicationsForProvisioning(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(apps) == 0 {
+		return nil, nil, fmt.Errorf("bonbon: no Bonbon application discovered for grant against %s", roleArn)
+	}
+
+	principalShape, err := principalShapeFromResource(principal)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	annos := annotations.Annotations{}
+	var grants []*v2.Grant
+	for _, appArn := range apps {
+		req := &CreateEntitlementRequest{
+			ApplicationArn: appArn,
+			PrincipalRole: PrincipalRoleEntitlement{
+				Principal: principalShape,
+				RoleArn:   roleArn,
+			},
+		}
+		resp, err := o.client.CreateEntitlement(ctx, req)
+		switch {
+		case err == nil:
+			g := grantSdk.NewGrant(entitlement.Resource, RoleAssignedEntitlement, principal.Id)
+			g.Id = encodeGrantExternalID(appArn, resp.EntitlementId)
+			grants = append(grants, g)
+		case IsAlreadyCreated(err):
+			annos.Append(&v2.GrantAlreadyExists{})
+			existing, lookupErr := o.findExistingEntitlement(ctx, appArn, roleArn, principalShape)
+			if lookupErr != nil {
+				l.Warn("bonbon: AlreadyCreatedException but lookup failed", zap.Error(lookupErr))
+				return nil, annos, nil
+			}
+			if existing == nil {
+				return nil, annos, nil
+			}
+			g := grantSdk.NewGrant(entitlement.Resource, RoleAssignedEntitlement, principal.Id)
+			g.Id = encodeGrantExternalID(appArn, existing.EntitlementId)
+			grants = append(grants, g)
+		default:
+			return nil, nil, mapProvisionError(err)
+		}
+	}
+	return grants, annos, nil
+}
+
+func (o *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
+	annos := annotations.Annotations{}
+	appArn, entitlementId, ok := decodeGrantExternalID(grant.Id)
+	if !ok {
+		recovered, err := o.recoverEntitlement(ctx, grant)
+		if err != nil {
+			return nil, err
+		}
+		if recovered == nil {
+			annos.Append(&v2.GrantAlreadyRevoked{})
+			return annos, nil
+		}
+		appArn = recovered.applicationArn
+		entitlementId = recovered.entitlementId
+	}
+
+	err := o.client.DeleteEntitlement(ctx, appArn, entitlementId)
+	switch {
+	case err == nil:
+		return annos, nil
+	case IsResourceNotFound(err):
+		annos.Append(&v2.GrantAlreadyRevoked{})
+		return annos, nil
+	default:
+		return nil, mapProvisionError(err)
+	}
+}
+
+type recoveredEntitlement struct {
+	applicationArn string
+	entitlementId  string
+}
+
+func (o *roleResourceType) recoverEntitlement(ctx context.Context, grant *v2.Grant) (*recoveredEntitlement, error) {
+	if grant.Entitlement == nil || grant.Entitlement.Resource == nil {
+		return nil, errors.New("bonbon: grant missing entitlement.resource")
+	}
+	roleArn := grant.Entitlement.Resource.Id.Resource
+
+	principalShape, err := principalShapeFromResource(grant.Principal)
+	if err != nil {
+		return nil, err
+	}
+
+	apps, err := o.applicationsForProvisioning(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, appArn := range apps {
+		existing, err := o.findExistingEntitlement(ctx, appArn, roleArn, principalShape)
+		if err != nil {
+			return nil, err
+		}
+		if existing != nil {
+			return &recoveredEntitlement{applicationArn: appArn, entitlementId: existing.EntitlementId}, nil
+		}
+	}
+	return nil, nil
+}
+
+// applicationsForProvisioning lists applications via a live API call —
+// Grant/Revoke do not receive a SyncOpAttrs and therefore have no session to
+// read from. CreateEntitlement/DeleteEntitlement run rarely enough that the
+// extra pagination is acceptable.
+func (o *roleResourceType) applicationsForProvisioning(ctx context.Context) ([]string, error) {
+	resp, err := o.client.ListApplications(ctx, &ListApplicationsRequest{})
+	if err != nil {
+		return nil, WrapForRetry(fmt.Errorf("bonbon: ListApplications (provision): %w", err))
+	}
+	out := make([]string, 0, len(resp.Applications))
+	for _, a := range resp.Applications {
+		out = append(out, a.ApplicationArn)
+	}
+	return out, nil
+}
+
+func (o *roleResourceType) findExistingEntitlement(ctx context.Context, appArn, roleArn string, principal Principal) (*EntitlementSummary, error) {
+	req := &ListEntitlementsRequest{
+		ApplicationArn: appArn,
+		Filter: EntitlementFilter{
+			PrincipalRole: &PrincipalRoleEntitlement{Principal: principal, RoleArn: roleArn},
+		},
+	}
+	resp, err := o.client.ListEntitlements(ctx, req)
+	if err != nil {
+		return nil, WrapForRetry(fmt.Errorf("bonbon: ListEntitlements: %w", err))
+	}
+	for i := range resp.Entitlements {
+		e := resp.Entitlements[i]
+		if e.PrincipalRole == nil || e.PrincipalRole.RoleArn != roleArn {
+			continue
+		}
+		if !principalEquals(e.PrincipalRole.Principal, principal) {
+			continue
+		}
+		return &e, nil
+	}
+	return nil, nil
+}
+
+func principalEquals(a, b Principal) bool {
+	if a.IdentityCenter == nil || b.IdentityCenter == nil {
+		return a.IdentityCenter == b.IdentityCenter
+	}
+	return a.IdentityCenter.UserId == b.IdentityCenter.UserId &&
+		a.IdentityCenter.GroupId == b.IdentityCenter.GroupId
+}
+
+func principalShapeFromResource(r *v2.Resource) (Principal, error) {
+	if r == nil || r.Id == nil {
+		return Principal{}, errors.New("bonbon: principal resource missing id")
+	}
+	id := lastPathSegment(r.Id.Resource)
+	switch r.Id.ResourceType {
+	case SSOUserResourceTypeId:
+		return Principal{IdentityCenter: &IdentityCenterPrincipal{UserId: id}}, nil
+	case SSOGroupResourceTypeId:
+		return Principal{IdentityCenter: &IdentityCenterPrincipal{GroupId: id}}, nil
+	default:
+		return Principal{}, fmt.Errorf("bonbon: unsupported principal resource type %q", r.Id.ResourceType)
+	}
+}
+
+func lastPathSegment(s string) string {
+	if idx := strings.LastIndex(s, "/"); idx >= 0 && idx+1 < len(s) {
+		return s[idx+1:]
+	}
+	return s
+}
+
+func encodeGrantExternalID(applicationArn, entitlementId string) string {
+	return roleAssignmentExternalIDPrefix + applicationArn + "|" + entitlementId
+}
+
+func decodeGrantExternalID(id string) (string, string, bool) {
+	if !strings.HasPrefix(id, roleAssignmentExternalIDPrefix) {
+		return "", "", false
+	}
+	rest := id[len(roleAssignmentExternalIDPrefix):]
+	idx := strings.Index(rest, "|")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// mapProvisionError turns the Bonbon-shaped error classes from § Error mapping
+// of the plan into operator-friendly messages. Validation errors are usually
+// the missing-trust-policy case — surface that hint inline.
+func mapProvisionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case IsValidation(err):
+		return fmt.Errorf("%w (likely the target IAM role is missing the %q trust policy)", err, servicePrincipal)
+	case IsAccessDenied(err):
+		return err
+	}
+	return WrapForRetry(err)
+}

--- a/pkg/connector/bonbon/session.go
+++ b/pkg/connector/bonbon/session.go
@@ -1,0 +1,84 @@
+package bonbon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+)
+
+const (
+	sessionKeyApplications = "bonbon:applications"
+	sessionKeyEntitlements = "bonbon:entitlements:"
+)
+
+// applicationList is the set of ARNs discovered during bonbon_application.List,
+// surfaced to bonbon_role.List so it knows which applications to iterate.
+type applicationList struct {
+	Arns []string `json:"arns"`
+}
+
+func writeApplications(ctx context.Context, sess sessions.SessionStore, arns []string) error {
+	if sess == nil {
+		return nil
+	}
+	v, err := json.Marshal(applicationList{Arns: arns})
+	if err != nil {
+		return fmt.Errorf("bonbon: encode application list: %w", err)
+	}
+	return sess.Set(ctx, sessionKeyApplications, v)
+}
+
+func readApplications(ctx context.Context, sess sessions.SessionStore) ([]string, error) {
+	if sess == nil {
+		return nil, nil
+	}
+	v, ok, err := sess.Get(ctx, sessionKeyApplications)
+	if err != nil {
+		return nil, fmt.Errorf("bonbon: read application list: %w", err)
+	}
+	if !ok {
+		return nil, nil
+	}
+	var list applicationList
+	if err := json.Unmarshal(v, &list); err != nil {
+		return nil, fmt.Errorf("bonbon: decode application list: %w", err)
+	}
+	return list.Arns, nil
+}
+
+// entitlementCache is keyed by applicationArn so role.List → role.Grants can
+// reuse the entitlement pagination output without re-walking the API.
+type entitlementCache struct {
+	Entitlements []EntitlementSummary `json:"entitlements"`
+}
+
+func writeEntitlements(ctx context.Context, sess sessions.SessionStore, applicationArn string, ents []EntitlementSummary) error {
+	if sess == nil {
+		return nil
+	}
+	v, err := json.Marshal(entitlementCache{Entitlements: ents})
+	if err != nil {
+		return fmt.Errorf("bonbon: encode entitlement cache: %w", err)
+	}
+	return sess.Set(ctx, sessionKeyEntitlements+applicationArn, v)
+}
+
+func readEntitlements(ctx context.Context, sess sessions.SessionStore, applicationArn string) ([]EntitlementSummary, bool, error) {
+	if sess == nil {
+		return nil, false, nil
+	}
+	v, ok, err := sess.Get(ctx, sessionKeyEntitlements+applicationArn)
+	if err != nil {
+		return nil, false, fmt.Errorf("bonbon: read entitlement cache: %w", err)
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	var c entitlementCache
+	if err := json.Unmarshal(v, &c); err != nil {
+		return nil, false, fmt.Errorf("bonbon: decode entitlement cache: %w", err)
+	}
+	return c.Entitlements, true, nil
+}

--- a/pkg/connector/bonbon/types.go
+++ b/pkg/connector/bonbon/types.go
@@ -1,0 +1,120 @@
+package bonbon
+
+import "encoding/json"
+
+const (
+	SigningName      = "account-access"
+	DefaultHostFmt   = "account-access.%s.amazonaws.com"
+	APIVersion       = "2018-05-10"
+	servicePrincipal = "account-access-preview.amazonaws.com"
+)
+
+type IdentityCenter struct {
+	InstanceArn string `json:"instanceArn,omitempty"`
+}
+
+type IdentitySource struct {
+	IdentityCenter *IdentityCenter `json:"identityCenter,omitempty"`
+}
+
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type ApplicationSummary struct {
+	ApplicationArn string `json:"applicationArn"`
+	TenantId       string `json:"tenantId,omitempty"`
+	Status         string `json:"status,omitempty"`
+}
+
+type Application struct {
+	ApplicationArn string          `json:"applicationArn"`
+	TenantId       string          `json:"tenantId,omitempty"`
+	Status         string          `json:"status,omitempty"`
+	IdentitySource *IdentitySource `json:"identitySource,omitempty"`
+	Tags           []Tag           `json:"tags,omitempty"`
+}
+
+type ListApplicationsRequest struct {
+	MaxResults int32  `json:"maxResults,omitempty"`
+	NextToken  string `json:"nextToken,omitempty"`
+}
+
+type ListApplicationsResponse struct {
+	Applications []ApplicationSummary `json:"applications"`
+	NextToken    string               `json:"nextToken,omitempty"`
+}
+
+type GetApplicationResponse = Application
+
+type ListTagsForResourceResponse struct {
+	Tags []Tag `json:"tags,omitempty"`
+}
+
+type IdentityCenterPrincipal struct {
+	UserId  string `json:"userId,omitempty"`
+	GroupId string `json:"groupId,omitempty"`
+}
+
+type Principal struct {
+	IdentityCenter *IdentityCenterPrincipal `json:"identityCenter,omitempty"`
+}
+
+type PrincipalRoleEntitlement struct {
+	Principal Principal `json:"principal"`
+	RoleArn   string    `json:"roleArn"`
+}
+
+type EntitlementMember struct {
+	PrincipalRole *PrincipalRoleEntitlement `json:"principalRole,omitempty"`
+}
+
+type EntitlementSummary struct {
+	EntitlementId  string                    `json:"entitlementId"`
+	ApplicationArn string                    `json:"applicationArn"`
+	PrincipalRole  *PrincipalRoleEntitlement `json:"principalRole,omitempty"`
+}
+
+type EntitlementFilter struct {
+	PrincipalRole *PrincipalRoleEntitlement `json:"principalRole,omitempty"`
+}
+
+type ListEntitlementsRequest struct {
+	ApplicationArn string            `json:"applicationArn"`
+	Filter         EntitlementFilter `json:"filter"`
+	MaxResults     int32             `json:"maxResults,omitempty"`
+	NextToken      string            `json:"nextToken,omitempty"`
+}
+
+type ListEntitlementsResponse struct {
+	Entitlements []EntitlementSummary `json:"entitlements"`
+	NextToken    string               `json:"nextToken,omitempty"`
+}
+
+type CreateEntitlementRequest struct {
+	ApplicationArn string                   `json:"applicationArn"`
+	PrincipalRole  PrincipalRoleEntitlement `json:"principalRole"`
+}
+
+type CreateEntitlementResponse struct {
+	EntitlementId  string `json:"entitlementId"`
+	ApplicationArn string `json:"applicationArn,omitempty"`
+}
+
+type GetEntitlementResponse struct {
+	EntitlementId  string                   `json:"entitlementId"`
+	ApplicationArn string                   `json:"applicationArn"`
+	PrincipalRole  PrincipalRoleEntitlement `json:"principalRole"`
+}
+
+type errorPayload struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+func decodeError(body []byte) errorPayload {
+	var p errorPayload
+	_ = json.Unmarshal(body, &p)
+	return p
+}

--- a/pkg/connector/bonbon_wiring.go
+++ b/pkg/connector/bonbon_wiring.go
@@ -1,0 +1,57 @@
+package connector
+
+import (
+	"context"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/conductorone/baton-aws/pkg/connector/bonbon"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+// BonbonConfig is the subset of Aws config that drives the Bonbon resource
+// syncers. Pulled out so the wiring stays independent of the baton-aws-wide
+// Config struct (eases the eventual move to a standalone baton-bonbon repo).
+type BonbonConfig struct {
+	Enabled        bool
+	Region         string
+	ApplicationArn string
+	BaseURL        string
+}
+
+// bonbonResourceSyncers returns the Bonbon resource syncers wired against the
+// supplied AWS config. Returns nil when disabled — callers append in place.
+func (c *AWS) bonbonResourceSyncers(ctx context.Context, bc BonbonConfig) []connectorbuilder.ResourceSyncerV2 {
+	l := ctxzap.Extract(ctx)
+	if !bc.Enabled {
+		return nil
+	}
+
+	awsCfg, err := c.getCallingConfig(ctx, c.globalRegion)
+	if err != nil {
+		l.Error("baton-aws: bonbon disabled — failed to load AWS calling config", zap.Error(err))
+		return nil
+	}
+
+	bonbonAwsCfg := awsCfg.Copy()
+	bonbonAwsCfg.Region = bc.Region
+
+	identityStoreId := ""
+	if c.identityInstance != nil {
+		identityStoreId = awsSdk.ToString(c.identityInstance.IdentityStoreId)
+	}
+
+	syncers, err := bonbon.ResourceSyncers(bonbonAwsCfg, bonbon.Config{
+		Region:          bc.Region,
+		ApplicationArn:  bc.ApplicationArn,
+		BaseURL:         bc.BaseURL,
+		SSORegion:       c.ssoRegion,
+		IdentityStoreId: identityStoreId,
+	})
+	if err != nil {
+		l.Error("baton-aws: bonbon disabled — region validation failed", zap.Error(err))
+		return nil
+	}
+	return syncers
+}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -20,6 +20,7 @@ import (
 	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	cfg "github.com/conductorone/baton-aws/pkg/config"
+	"github.com/conductorone/baton-aws/pkg/connector/bonbon"
 	"github.com/conductorone/baton-aws/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -38,23 +39,27 @@ const (
 )
 
 type Config struct {
-	UseAssumeRole           bool
-	GlobalBindingExternalID string
-	GlobalRegion            string
-	GlobalRoleARN           string
-	GlobalSecretAccessKey   string
-	GlobalAccessKeyID       string
-	GlobalAwsSsoRegion      string
-	GlobalAwsOrgsEnabled    bool
-	GlobalAwsSsoEnabled     bool
-	ExternalID              string
-	RoleARN                 string
-	SCIMToken               string
-	SCIMEndpoint            string
-	SCIMEnabled             bool
-	SyncSecrets             bool
-	IamAssumeRoleName       string
-	SyncSSOUserLastLogin    bool
+	UseAssumeRole              bool
+	GlobalBindingExternalID    string
+	GlobalRegion               string
+	GlobalRoleARN              string
+	GlobalSecretAccessKey      string
+	GlobalAccessKeyID          string
+	GlobalAwsSsoRegion         string
+	GlobalAwsOrgsEnabled       bool
+	GlobalAwsSsoEnabled        bool
+	ExternalID                 string
+	RoleARN                    string
+	SCIMToken                  string
+	SCIMEndpoint               string
+	SCIMEnabled                bool
+	SyncSecrets                bool
+	IamAssumeRoleName          string
+	SyncSSOUserLastLogin       bool
+	GlobalBonbonEnabled        bool
+	GlobalBonbonRegion         string
+	GlobalBonbonApplicationArn string
+	GlobalBonbonBaseURL        string
 }
 
 type AWS struct {
@@ -89,6 +94,8 @@ type AWS struct {
 
 	syncSecrets          bool
 	syncSSOUserLastLogin bool
+
+	bonbonConfig BonbonConfig
 }
 
 func (o *AWS) getIAMClient(ctx context.Context) (*iam.Client, error) {
@@ -234,20 +241,24 @@ func New(ctx context.Context, awsc *cfg.Aws, _ *cli.ConnectorOpts) (connectorbui
 	}
 
 	config := Config{
-		GlobalBindingExternalID: awsc.GlobalBindingExternalId,
-		GlobalRegion:            awsc.GlobalRegion,
-		GlobalRoleARN:           awsc.GlobalRoleArn,
-		GlobalSecretAccessKey:   awsc.GlobalSecretAccessKey,
-		GlobalAccessKeyID:       awsc.GlobalAccessKeyId,
-		GlobalAwsSsoRegion:      awsc.GlobalAwsSsoRegion,
-		GlobalAwsOrgsEnabled:    awsc.GlobalAwsOrgsEnabled,
-		GlobalAwsSsoEnabled:     awsc.GlobalAwsSsoEnabled,
-		ExternalID:              awsc.ExternalId,
-		RoleARN:                 awsc.RoleArn,
-		UseAssumeRole:           awsc.UseAssume,
-		SyncSecrets:             awsc.SyncSecrets,
-		IamAssumeRoleName:       awsc.IamAssumeRoleName,
-		SyncSSOUserLastLogin:    awsc.SyncSsoUserLastLogin,
+		GlobalBindingExternalID:    awsc.GlobalBindingExternalId,
+		GlobalRegion:               awsc.GlobalRegion,
+		GlobalRoleARN:              awsc.GlobalRoleArn,
+		GlobalSecretAccessKey:      awsc.GlobalSecretAccessKey,
+		GlobalAccessKeyID:          awsc.GlobalAccessKeyId,
+		GlobalAwsSsoRegion:         awsc.GlobalAwsSsoRegion,
+		GlobalAwsOrgsEnabled:       awsc.GlobalAwsOrgsEnabled,
+		GlobalAwsSsoEnabled:        awsc.GlobalAwsSsoEnabled,
+		ExternalID:                 awsc.ExternalId,
+		RoleARN:                    awsc.RoleArn,
+		UseAssumeRole:              awsc.UseAssume,
+		SyncSecrets:                awsc.SyncSecrets,
+		IamAssumeRoleName:          awsc.IamAssumeRoleName,
+		SyncSSOUserLastLogin:       awsc.SyncSsoUserLastLogin,
+		GlobalBonbonEnabled:        awsc.GlobalBonbonEnabled,
+		GlobalBonbonRegion:         awsc.GlobalBonbonRegion,
+		GlobalBonbonApplicationArn: awsc.GlobalBonbonApplicationArn,
+		GlobalBonbonBaseURL:        awsc.GlobalBonbonBaseUrl,
 	}
 
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, l))
@@ -281,6 +292,12 @@ func New(ctx context.Context, awsc *cfg.Aws, _ *cli.ConnectorOpts) (connectorbui
 		_callingConfigError:     map[string]error{},
 		syncSecrets:             config.SyncSecrets,
 		syncSSOUserLastLogin:    config.SyncSSOUserLastLogin,
+		bonbonConfig: BonbonConfig{
+			Enabled:        config.GlobalBonbonEnabled,
+			Region:         config.GlobalBonbonRegion,
+			ApplicationArn: config.GlobalBonbonApplicationArn,
+			BaseURL:        config.GlobalBonbonBaseURL,
+		},
 	}
 
 	rv.awsClientFactory = NewAWSClientFactory(config, rv, httpClient)
@@ -453,6 +470,11 @@ func (c *AWS) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSy
 		l.Debug("syncSecrets. creating secretBuilder")
 		rs = append(rs, secretBuilder(c.iamClient, c.awsClientFactory))
 	}
+
+	if c.bonbonConfig.Enabled {
+		l.Debug("bonbonEnabled. creating bonbon resource syncers")
+		rs = append(rs, c.bonbonResourceSyncers(ctx, c.bonbonConfig)...)
+	}
 	return rs
 }
 
@@ -473,7 +495,7 @@ func (d *defaultCapabilitiesBuilder) Validate(_ context.Context) (annotations.An
 }
 
 func (d *defaultCapabilitiesBuilder) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
-	return []connectorbuilder.ResourceSyncerV2{
+	rs := []connectorbuilder.ResourceSyncerV2{
 		iamUserBuilder(nil, nil),
 		iamRoleBuilder(nil, nil),
 		iamGroupBuilder(nil, nil),
@@ -483,6 +505,8 @@ func (d *defaultCapabilitiesBuilder) ResourceSyncers(_ context.Context) []connec
 		accountIAMBuilder(nil, nil, nil),
 		secretBuilder(nil, nil),
 	}
+	rs = append(rs, bonbon.DefaultCapabilities()...)
+	return rs
 }
 
 func (c *AWS) EventFeeds(ctx context.Context) []connectorbuilder.EventFeed {

--- a/test/bonbon-testserver/server.go
+++ b/test/bonbon-testserver/server.go
@@ -1,0 +1,389 @@
+// Package bonbontest stands up an in-memory HTTP fake of the AWS Account
+// Access Manager API (codename: Bonbon). It accepts any signed request — the
+// SigV4 code path in the production client is exercised end-to-end by going
+// through Client.do(), but the server itself does not validate signatures.
+// The seed graph is documented at the top of NewTestServer and matches the
+// expectations in connector_test.go.
+package bonbontest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/conductorone/baton-aws/pkg/connector/bonbon"
+)
+
+const (
+	testAppArn = "arn:aws:account-access:us-east-1:123456789012:application/app-bonbon-1"
+	testRole1  = "arn:aws:iam::123456789012:role/BonbonRoleAlpha"
+	testRole2  = "arn:aws:iam::123456789012:role/BonbonRoleBeta"
+
+	UserId1  = "11111111-aaaa-bbbb-cccc-111111111111"
+	UserId2  = "22222222-aaaa-bbbb-cccc-222222222222"
+	UserId3  = "33333333-aaaa-bbbb-cccc-333333333333"
+	GroupId1 = "44444444-dddd-eeee-ffff-444444444444"
+	GroupId2 = "55555555-dddd-eeee-ffff-555555555555"
+)
+
+// TestAppArn / TestRoles are the canonical seed identifiers tests assert against.
+func TestAppArn() string     { return testAppArn }
+func TestRoleArns() []string { return []string{testRole1, testRole2} }
+
+// Server is the test fake. Use New() to construct one with the default seed
+// graph, then call URL() for the base URL to pass into bonbon.NewClient.
+type Server struct {
+	mu sync.Mutex
+
+	httpServer *httptest.Server
+
+	applications map[string]bonbon.Application
+	entitlements map[string]map[string]bonbon.EntitlementSummary
+
+	idSeq int
+}
+
+func New() *Server {
+	s := &Server{
+		applications: map[string]bonbon.Application{},
+		entitlements: map[string]map[string]bonbon.EntitlementSummary{},
+	}
+	s.seed()
+	s.httpServer = httptest.NewServer(http.HandlerFunc(s.route))
+	return s
+}
+
+func (s *Server) Close()         { s.httpServer.Close() }
+func (s *Server) URL() string    { return s.httpServer.URL }
+func (s *Server) AppArn() string { return testAppArn }
+
+func (s *Server) seed() {
+	s.applications[testAppArn] = bonbon.Application{
+		ApplicationArn: testAppArn,
+		TenantId:       "tenant-bonbon",
+		Status:         "ACTIVE",
+		IdentitySource: &bonbon.IdentitySource{
+			IdentityCenter: &bonbon.IdentityCenter{InstanceArn: "arn:aws:sso:::instance/ssoins-test"},
+		},
+		Tags: []bonbon.Tag{{Key: "env", Value: "test"}},
+	}
+
+	entries := []struct {
+		role  string
+		user  string
+		group string
+	}{
+		{role: testRole1, user: UserId1},
+		{role: testRole1, user: UserId2},
+		{role: testRole1, group: GroupId1},
+		{role: testRole2, user: UserId3},
+		{role: testRole2, group: GroupId2},
+	}
+	for _, e := range entries {
+		p := bonbon.Principal{IdentityCenter: &bonbon.IdentityCenterPrincipal{}}
+		switch {
+		case e.user != "":
+			p.IdentityCenter.UserId = e.user
+		case e.group != "":
+			p.IdentityCenter.GroupId = e.group
+		}
+		s.addEntitlement(testAppArn, e.role, p)
+	}
+}
+
+func (s *Server) addEntitlement(appArn, roleArn string, p bonbon.Principal) bonbon.EntitlementSummary {
+	s.idSeq++
+	id := fmt.Sprintf("ent-%04d", s.idSeq)
+	sum := bonbon.EntitlementSummary{
+		EntitlementId:  id,
+		ApplicationArn: appArn,
+		PrincipalRole: &bonbon.PrincipalRoleEntitlement{
+			Principal: p,
+			RoleArn:   roleArn,
+		},
+	}
+	if _, ok := s.entitlements[appArn]; !ok {
+		s.entitlements[appArn] = map[string]bonbon.EntitlementSummary{}
+	}
+	s.entitlements[appArn][id] = sum
+	return sum
+}
+
+// Counts exposes counters for assertions: total applications + total entitlements.
+func (s *Server) Counts() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entitlements := 0
+	for _, m := range s.entitlements {
+		entitlements += len(m)
+	}
+	return len(s.applications), entitlements
+}
+
+func (s *Server) route(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/applications-list":
+		s.handleListApplications(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/applications/"):
+		s.handleGetApplication(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/tags/"):
+		s.handleListTags(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/entitlements-list":
+		s.handleListEntitlements(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/entitlements":
+		s.handleCreateEntitlement(w, r)
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/entitlements/"):
+		s.handleDeleteEntitlement(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/entitlements/"):
+		s.handleGetEntitlement(w, r)
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+}
+
+func (s *Server) handleListApplications(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var req bonbon.ListApplicationsRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	all := make([]bonbon.ApplicationSummary, 0, len(s.applications))
+	for _, app := range s.applications {
+		all = append(all, bonbon.ApplicationSummary{
+			ApplicationArn: app.ApplicationArn,
+			TenantId:       app.TenantId,
+			Status:         app.Status,
+		})
+	}
+	writeJSON(w, http.StatusOK, bonbon.ListApplicationsResponse{Applications: all})
+}
+
+func (s *Server) handleGetApplication(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	encoded := strings.TrimPrefix(r.URL.Path, "/applications/")
+	arn, err := url.PathUnescape(encoded)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		return
+	}
+	app, ok := s.applications[arn]
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such application")
+		return
+	}
+	writeJSON(w, http.StatusOK, app)
+}
+
+func (s *Server) handleListTags(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	encoded := strings.TrimPrefix(r.URL.Path, "/tags/")
+	arn, err := url.PathUnescape(encoded)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		return
+	}
+	if app, ok := s.applications[arn]; ok {
+		writeJSON(w, http.StatusOK, bonbon.ListTagsForResourceResponse{Tags: app.Tags})
+		return
+	}
+	writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such resource")
+}
+
+func (s *Server) handleListEntitlements(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var req bonbon.ListEntitlementsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		return
+	}
+	if req.ApplicationArn == "" {
+		writeError(w, http.StatusBadRequest, "ValidationException", "applicationArn is required")
+		return
+	}
+
+	pool, ok := s.entitlements[req.ApplicationArn]
+	if !ok {
+		writeJSON(w, http.StatusOK, bonbon.ListEntitlementsResponse{})
+		return
+	}
+
+	out := make([]bonbon.EntitlementSummary, 0, len(pool))
+	for _, e := range pool {
+		if req.Filter.PrincipalRole != nil {
+			f := req.Filter.PrincipalRole
+			if f.RoleArn != "" && f.RoleArn != e.PrincipalRole.RoleArn {
+				continue
+			}
+			if f.Principal.IdentityCenter != nil && e.PrincipalRole.Principal.IdentityCenter != nil {
+				if f.Principal.IdentityCenter.UserId != "" && f.Principal.IdentityCenter.UserId != e.PrincipalRole.Principal.IdentityCenter.UserId {
+					continue
+				}
+				if f.Principal.IdentityCenter.GroupId != "" && f.Principal.IdentityCenter.GroupId != e.PrincipalRole.Principal.IdentityCenter.GroupId {
+					continue
+				}
+			}
+		}
+		out = append(out, e)
+	}
+	writeJSON(w, http.StatusOK, bonbon.ListEntitlementsResponse{Entitlements: out})
+}
+
+func (s *Server) handleCreateEntitlement(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var req bonbon.CreateEntitlementRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		return
+	}
+	if req.ApplicationArn == "" || req.PrincipalRole.RoleArn == "" {
+		writeError(w, http.StatusBadRequest, "ValidationException", "applicationArn and principalRole.roleArn are required")
+		return
+	}
+
+	pool, ok := s.entitlements[req.ApplicationArn]
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such application")
+		return
+	}
+
+	for _, e := range pool {
+		if e.PrincipalRole == nil {
+			continue
+		}
+		if e.PrincipalRole.RoleArn != req.PrincipalRole.RoleArn {
+			continue
+		}
+		if !principalEquals(e.PrincipalRole.Principal, req.PrincipalRole.Principal) {
+			continue
+		}
+		writeError(w, http.StatusConflict, "AlreadyCreatedException", "entitlement already exists")
+		return
+	}
+
+	sum := s.addEntitlement(req.ApplicationArn, req.PrincipalRole.RoleArn, req.PrincipalRole.Principal)
+	writeJSON(w, http.StatusOK, bonbon.CreateEntitlementResponse{
+		EntitlementId:  sum.EntitlementId,
+		ApplicationArn: sum.ApplicationArn,
+	})
+}
+
+func (s *Server) handleDeleteEntitlement(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	encoded := strings.TrimPrefix(r.URL.Path, "/entitlements/")
+	id, err := url.PathUnescape(encoded)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		return
+	}
+	appArn := r.URL.Query().Get("applicationArn")
+	if appArn == "" {
+		writeError(w, http.StatusBadRequest, "ValidationException", "applicationArn is required")
+		return
+	}
+	pool, ok := s.entitlements[appArn]
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such application")
+		return
+	}
+	if _, ok := pool[id]; !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such entitlement")
+		return
+	}
+	delete(pool, id)
+	writeJSON(w, http.StatusOK, struct{}{})
+}
+
+func (s *Server) handleGetEntitlement(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	encoded := strings.TrimPrefix(r.URL.Path, "/entitlements/")
+	id, err := url.PathUnescape(encoded)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		return
+	}
+	appArn := r.URL.Query().Get("applicationArn")
+	pool, ok := s.entitlements[appArn]
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such application")
+		return
+	}
+	e, ok := pool[id]
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no such entitlement")
+		return
+	}
+	writeJSON(w, http.StatusOK, bonbon.GetEntitlementResponse{
+		EntitlementId:  e.EntitlementId,
+		ApplicationArn: e.ApplicationArn,
+		PrincipalRole:  *e.PrincipalRole,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, errType, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Amzn-ErrorType", errType)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"__type":  errType,
+		"message": msg,
+	})
+}
+
+func principalEquals(a, b bonbon.Principal) bool {
+	if a.IdentityCenter == nil || b.IdentityCenter == nil {
+		return a.IdentityCenter == b.IdentityCenter
+	}
+	return a.IdentityCenter.UserId == b.IdentityCenter.UserId &&
+		a.IdentityCenter.GroupId == b.IdentityCenter.GroupId
+}
+
+// EntitlementCount returns total seeded entitlements for direct assertions.
+func (s *Server) EntitlementCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, m := range s.entitlements {
+		n += len(m)
+	}
+	return n
+}
+
+// ApplicationCount returns total seeded applications.
+func (s *Server) ApplicationCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.applications)
+}
+
+// ItoaIDs is a helper for round-trip tests over entitlement ids.
+func ItoaIDs(ids []int) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = strconv.Itoa(id)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in, plain-Go path for AWS Account Access Manager (codename: **Bonbon**) alongside the existing IAM / IdC / Orgs syncs in `baton-aws`. Two resource types — `bonbon_application` (`TRAIT_APP`) and `bonbon_role` (`TRAIT_ROLE`) — both annotated `OptInRequired{}` because the AWS service itself is still in private preview.
- Hand-rolls a SigV4 REST/JSON client (`pkg/connector/bonbon/client.go`) against the 11 documented `account-access` operations because the service is not in `aws-sdk-go-v2`. Reuses the existing baton-aws AssumeRole + external-id credential chain — operators already onboarded for `baton-aws` do not need new auth wiring.
- Gated end-to-end by `--global-bonbon-enabled` (default `false`). Region is restricted at parse time to `us-east-1` / `us-west-2`; outside-set values are rejected with an explicit "private preview region" error. Grants on `bonbon_role` map to `CreateEntitlement` / `DeleteEntitlement` with idempotent semantics on both ends.
- In-memory testserver (`test/bonbon-testserver/`) serves the 11 routes against a seeded application + entitlement graph. `TestBonbonFullSync` and `TestBonbonGrantRevoke` drive the production builders end-to-end through SigV4 → HTTP → JSON.

## Architecture note

The plan favored a standalone `ConductorOne/baton-bonbon` repo. The current scaffold lives under `baton-aws/pkg/connector/bonbon/` because the gh App installation cannot create repos under the `ConductorOne` org — re-confirmed at scaffold time. The directory is self-contained and copy-movable to a new repo with a single import-path rename when a maintainer creates the repo.

## Test Plan

- [x] `gofmt -l ./...` clean across new and touched files
- [x] `go vet ./...` clean
- [x] `go test ./...` — `TestBonbonFullSync`, `TestBonbonGrantRevoke`, `TestValidateRegion`, plus added region-validation cases in `TestConfigs`
- [x] `golangci-lint run` clean
- [ ] Manual smoke against a real Bonbon-enabled account (private preview) — requires a Bonbon-enabled test account; documented in `docs/bonbon.md`. Connector remains DRAFT until this is done.

## Risks

- The SigV4 path is exercised end-to-end by tests but the testserver does not validate signatures. A real-account smoke is the only signal that the signing scope (`account-access` / region) is correct.
- `AlreadyCreatedException` HTTP status is not pinned by the service-2.json. The error parser reads `__type` / `X-Amzn-ErrorType` rather than relying on status, but the actual status code wants real-account confirmation before GA.
- `connectorbuilder.NewSyncTestRunner` referenced in the plan is not in the currently vendored baton-sdk — direct builder-method tests are used instead, matching the existing `sso_group_test.go` pattern in `baton-aws`. Open question for the eventual move to a standalone repo.

## Open questions

1. **Repo home.** Plan recommends a standalone `baton-bonbon` repo. Blocked at scaffold time by gh App permissions; the directory is self-contained for migration once a maintainer creates the repo.
2. **`AlreadyCreatedException` HTTP code.** Service-2.json declares the shape but does not pin a status. Parser reads `__type` / header; real-account verification wanted before GA.
3. **Entitlement tags.** Bonbon supports tags on entitlements. Scaffold ignores them; product-shaped open question.

---

_🛰️ Built with stargate._