### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -632,7 +632,7 @@ spec:
     spec:
       containers:
       - name: baton-aws
-        image: ghcr.io/conductorone/baton-aws:latest
+        image: public.ecr.aws/conductorone/baton-aws:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._