### PR TITLE
CXH-1708: make iam_user CreateAccount idempotent on EntityAlreadyExists

### DIFF
--- a/.claude/skills/connector/build-provisioning.md
+++ b/.claude/skills/connector/build-provisioning.md
@@ -210,6 +210,35 @@ func (u *userBuilder) CreateAccount(ctx context.Context, accountInfo *v2.Account
 
 ---
 
+## CreateAccount Idempotency
+
+`CreateAccount` is retried by the SDK on transient failures. If the user already exists in the target system, the second call must NOT surface an error. Return `CreateAccountResponse_AlreadyExistsResult` populated with the existing resource.
+
+```go
+newUser, err := u.client.CreateUser(ctx, ...)
+if err != nil {
+    if isAlreadyExistsError(err) {
+        existing, lookupErr := u.client.GetUser(ctx, username)
+        if lookupErr != nil {
+            return nil, nil, nil, fmt.Errorf("baton-myservice: user %q already exists but lookup failed: %w", username, lookupErr)
+        }
+        return &v2.CreateAccountResponse_AlreadyExistsResult{
+            Resource:              existing,
+            IsCreateAccountResult: true,
+        }, nil, nil, nil
+    }
+    return nil, nil, nil, fmt.Errorf("baton-myservice: CreateUser failed: %w", err)
+}
+```
+
+**Do not pick a gRPC code by hand on the lookup failure.** Returning a hand-picked `status.Errorf(codes.PermissionDenied, ...)` (or `codes.Internal`, etc.) is wrong for a lookup that can fail for many reasons (throttling, transient service failure, network). If the underlying client goes through `uhttp.BaseHttpClient`, uhttp has already classified the response — return the wrapped error directly. If it goes through a vendor SDK that bypasses uhttp, route the error through the connector's existing AWS/HTTP error helper (e.g., `wrapAWSError`) instead of inventing a code at the call site.
+
+**Use `AlreadyExistsResult`, not `SuccessResult`.** `SuccessResult` signals "I just created this"; `AlreadyExistsResult` signals "it was already there." They are distinct in the protobuf for a reason.
+
+**`AlreadyExistsResult` is for direct resource creates (IAM user, native API user).** For invitation flows (CreateAccount issues an invitation rather than a finished resource), use `CreateAccountResponse_ActionRequiredResult`. Don't mix them.
+
+---
+
 ## Capability Declaration
 
 Provisioning capabilities must be declared:

--- a/pkg/connector/iam_user.go
+++ b/pkg/connector/iam_user.go
@@ -256,7 +256,7 @@ func (o *iamUserResourceType) CreateAccount(
 		if errors.As(err, &alreadyExists) {
 			existing, lookupErr := o.findIamUserByUserName(ctx, username)
 			if lookupErr != nil {
-				return nil, nil, nil, status.Errorf(codes.PermissionDenied, "baton-aws: iam user %q already exists but lookup via iam:GetUser failed: %v", username, lookupErr)
+				return nil, nil, nil, fmt.Errorf("baton-aws: iam user %q already exists but lookup via iam:GetUser failed: %w", username, lookupErr)
 			}
 			return &v2.CreateAccountResponse_AlreadyExistsResult{
 				Resource:              existing,

--- a/pkg/connector/iam_user.go
+++ b/pkg/connector/iam_user.go
@@ -240,30 +240,6 @@ func (o *iamUserResourceType) CreateAccount(
 		username = email
 	}
 
-	if result, err := o.iamClient.GetUser(ctx, &iam.GetUserInput{UserName: awsSdk.String(username)}); err == nil {
-		var noSuchEntity *iamTypes.NoSuchEntityException
-		if errors.As(err, &noSuchEntity) {
-			return nil, nil, nil, fmt.Errorf("baton-aws: iam.GetUser failed: %w", err)
-		}
-		annos := &v2.V1Identifier{
-			Id: awsSdk.ToString(result.User.Arn),
-		}
-		userResource, err := resourceSdk.NewUserResource(awsSdk.ToString(result.User.UserName),
-			resourceTypeIAMUser,
-			awsSdk.ToString(result.User.Arn),
-			nil,
-			resourceSdk.WithAnnotation(annos),
-		)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		return &v2.CreateAccountResponse_SuccessResult{
-			Resource:              userResource,
-			IsCreateAccountResult: true,
-		}, nil, nil, nil
-	}
-
 	createUserInput := &iam.CreateUserInput{
 		UserName: awsSdk.String(username),
 	}
@@ -276,18 +252,21 @@ func (o *iamUserResourceType) CreateAccount(
 
 	result, err := o.iamClient.CreateUser(ctx, createUserInput)
 	if err != nil {
+		var alreadyExists *iamTypes.EntityAlreadyExistsException
+		if errors.As(err, &alreadyExists) {
+			existing, lookupErr := o.findIamUserByUserName(ctx, username)
+			if lookupErr != nil {
+				return nil, nil, nil, status.Errorf(codes.PermissionDenied, "baton-aws: iam user %q already exists but lookup via iam:GetUser failed: %v", username, lookupErr)
+			}
+			return &v2.CreateAccountResponse_AlreadyExistsResult{
+				Resource:              existing,
+				IsCreateAccountResult: true,
+			}, nil, nil, nil
+		}
 		return nil, nil, nil, wrapAWSError(fmt.Errorf("baton-aws: iam.CreateUser failed: %w", err))
 	}
 
-	annos := &v2.V1Identifier{
-		Id: awsSdk.ToString(result.User.Arn),
-	}
-	userResource, err := resourceSdk.NewUserResource(awsSdk.ToString(result.User.UserName),
-		resourceTypeIAMUser,
-		awsSdk.ToString(result.User.Arn),
-		nil,
-		resourceSdk.WithAnnotation(annos),
-	)
+	userResource, err := iamUserToResource(result.User)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -296,6 +275,25 @@ func (o *iamUserResourceType) CreateAccount(
 		Resource:              userResource,
 		IsCreateAccountResult: true,
 	}, nil, nil, nil
+}
+
+func iamUserToResource(user *iamTypes.User) (*v2.Resource, error) {
+	arn := awsSdk.ToString(user.Arn)
+	return resourceSdk.NewUserResource(
+		awsSdk.ToString(user.UserName),
+		resourceTypeIAMUser,
+		arn,
+		nil,
+		resourceSdk.WithAnnotation(&v2.V1Identifier{Id: arn}),
+	)
+}
+
+func (o *iamUserResourceType) findIamUserByUserName(ctx context.Context, username string) (*v2.Resource, error) {
+	out, err := o.iamClient.GetUser(ctx, &iam.GetUserInput{UserName: awsSdk.String(username)})
+	if err != nil {
+		return nil, fmt.Errorf("baton-aws: iam.GetUser %q: %w", username, err)
+	}
+	return iamUserToResource(out.User)
 }
 
 func (o *iamUserResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId, parentResourceID *v2.ResourceId) (annotations.Annotations, error) {

--- a/pkg/connector/iam_user.go
+++ b/pkg/connector/iam_user.go
@@ -254,7 +254,7 @@ func (o *iamUserResourceType) CreateAccount(
 	if err != nil {
 		var alreadyExists *iamTypes.EntityAlreadyExistsException
 		if errors.As(err, &alreadyExists) {
-			existing, lookupErr := o.findIamUserByUserName(ctx, username)
+			existing, lookupErr := o.findIamUserByUserName(ctx, username, email)
 			if lookupErr != nil {
 				return nil, nil, nil, fmt.Errorf("baton-aws: iam user %q already exists but lookup via iam:GetUser failed: %w", username, lookupErr)
 			}
@@ -266,7 +266,7 @@ func (o *iamUserResourceType) CreateAccount(
 		return nil, nil, nil, wrapAWSError(fmt.Errorf("baton-aws: iam.CreateUser failed: %w", err))
 	}
 
-	userResource, err := iamUserToResource(result.User)
+	userResource, err := iamUserToResource(ctx, result.User, email)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -277,23 +277,38 @@ func (o *iamUserResourceType) CreateAccount(
 	}, nil, nil, nil
 }
 
-func iamUserToResource(user *iamTypes.User) (*v2.Resource, error) {
+func iamUserToResource(ctx context.Context, user *iamTypes.User, email string) (*v2.Resource, error) {
 	arn := awsSdk.ToString(user.Arn)
+	options := []resourceSdk.UserTraitOption{
+		resourceSdk.WithUserProfile(iamUserProfile(ctx, *user)),
+	}
+	seen := map[string]bool{}
+	if email != "" {
+		options = append(options, resourceSdk.WithEmail(email, true))
+		seen[email] = true
+	}
+	for _, e := range getUserEmails(*user) {
+		if seen[e] {
+			continue
+		}
+		options = append(options, resourceSdk.WithEmail(e, email == ""))
+		seen[e] = true
+	}
 	return resourceSdk.NewUserResource(
 		awsSdk.ToString(user.UserName),
 		resourceTypeIAMUser,
 		arn,
-		nil,
+		options,
 		resourceSdk.WithAnnotation(&v2.V1Identifier{Id: arn}),
 	)
 }
 
-func (o *iamUserResourceType) findIamUserByUserName(ctx context.Context, username string) (*v2.Resource, error) {
+func (o *iamUserResourceType) findIamUserByUserName(ctx context.Context, username, email string) (*v2.Resource, error) {
 	out, err := o.iamClient.GetUser(ctx, &iam.GetUserInput{UserName: awsSdk.String(username)})
 	if err != nil {
 		return nil, fmt.Errorf("baton-aws: iam.GetUser %q: %w", username, err)
 	}
-	return iamUserToResource(out.User)
+	return iamUserToResource(ctx, out.User, email)
 }
 
 func (o *iamUserResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId, parentResourceID *v2.ResourceId) (annotations.Annotations, error) {

--- a/pkg/connector/iam_user_test.go
+++ b/pkg/connector/iam_user_test.go
@@ -1,0 +1,78 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIamUserToResource_AttachesEmailAndProfile(t *testing.T) {
+	user := &iamTypes.User{
+		UserName: awsSdk.String("ci-iam-1"),
+		Arn:      awsSdk.String("arn:aws:iam::123456789012:user/ci-iam-1"),
+		Path:     awsSdk.String("/"),
+		UserId:   awsSdk.String("AIDAEXAMPLE"),
+	}
+
+	resource, err := iamUserToResource(context.Background(), user, "ci-iam-1@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+
+	trait, err := resourceSdk.GetUserTrait(resource)
+	require.NoError(t, err)
+	require.NotNil(t, trait, "user trait must be attached")
+
+	emails := trait.GetEmails()
+	require.NotEmpty(t, emails, "email trait must be present")
+	assert.Equal(t, "ci-iam-1@example.com", emails[0].GetAddress())
+	assert.True(t, emails[0].GetIsPrimary(), "passed-in email should be marked primary")
+
+	profile := trait.GetProfile().AsMap()
+	assert.Equal(t, "arn:aws:iam::123456789012:user/ci-iam-1", profile["aws_arn"])
+	assert.Equal(t, "AIDAEXAMPLE", profile["aws_user_id"])
+	assert.Equal(t, iamType, profile["aws_user_type"])
+}
+
+func TestIamUserToResource_NoEmailFallsBackToUsername(t *testing.T) {
+	user := &iamTypes.User{
+		UserName: awsSdk.String("user@example.com"),
+		Arn:      awsSdk.String("arn:aws:iam::123456789012:user/user@example.com"),
+		Path:     awsSdk.String("/"),
+		UserId:   awsSdk.String("AIDAEXAMPLE2"),
+	}
+
+	resource, err := iamUserToResource(context.Background(), user, "")
+	require.NoError(t, err)
+
+	trait, err := resourceSdk.GetUserTrait(resource)
+	require.NoError(t, err)
+
+	emails := trait.GetEmails()
+	require.Len(t, emails, 1, "username-as-email should be picked up by getUserEmails")
+	assert.Equal(t, "user@example.com", emails[0].GetAddress())
+	assert.True(t, emails[0].GetIsPrimary(), "fallback email should be primary when no explicit email passed")
+}
+
+func TestIamUserToResource_DedupesEmailFromUsername(t *testing.T) {
+	user := &iamTypes.User{
+		UserName: awsSdk.String("dup@example.com"),
+		Arn:      awsSdk.String("arn:aws:iam::123456789012:user/dup@example.com"),
+		Path:     awsSdk.String("/"),
+		UserId:   awsSdk.String("AIDAEXAMPLE3"),
+	}
+
+	resource, err := iamUserToResource(context.Background(), user, "dup@example.com")
+	require.NoError(t, err)
+
+	trait, err := resourceSdk.GetUserTrait(resource)
+	require.NoError(t, err)
+
+	emails := trait.GetEmails()
+	require.Len(t, emails, 1, "email passed in must not be duplicated by getUserEmails")
+	assert.Equal(t, "dup@example.com", emails[0].GetAddress())
+}


### PR DESCRIPTION
Creating an AWS IAM user that already exists no longer fails the access request — the connector now treats it as success and links the existing user, so just-in-time provisioning completes instead of stalling.