### PR TITLE
CXP-752: Document Sparse ACL support for Identity Center permission sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Set the `--global-aws-sso-enabled` and `--global-aws-orgs-enabled` flags to pull
 
 By default, `baton-aws` uses the AWS credentials from your AWS config. You can explicitly define the region, access key, and secret key by setting the following flags: `--global-secret-access-key`, `--global-access-key-id`, `--global-region`.
 
+## Sparse ACLs: permission sets as scoped bindings
+
+With both `--global-aws-orgs-enabled` and `--global-aws-sso-enabled` set, `baton-aws` can additionally model Identity Center permission set assignments as **Sparse ACL** bindings, alongside the legacy flat per-account entitlement model. This adds four resource types:
+
+- **Organization Root** and **Organizational Unit** — the AWS Organizations hierarchy (Root → OU → Account), synced as read-only navigation/review context. Neither carries any bindings of its own.
+- **Permission Set** — a role catalog entry for each Identity Center permission set.
+- **Permission Set Assignment** — one binding per (permission set, account) pair that is actually assigned, carrying the principals (users/groups) granted that permission set on that account. Group grants expand to their members.
+
+Instead of a flat list of one row per (account, permission set, user) combination, reviewers see "Permission Set X on Account Y" as a single reviewable item, with the AWS Organizations hierarchy providing context for where that access applies.
+
+These four resource types are also marked **opt-in** on the ConductorOne platform: even with both flags enabled, a tenant must separately opt in (per resource type) in the C1 UI before C1 begins syncing them. This makes rollout safe — existing connectors keep syncing the legacy flat model until an admin opts in to Sparse ACLs.
+
+`organizations:ListRoots` and `organizations:ListOrganizationalUnitsForParent` are required to sync the Organization Root / Organizational Unit hierarchy; if missing, the connector logs a warning and skips the hierarchy rather than failing the sync (accounts stay flat, ungrouped by OU). See the IAM policies below for where to add them.
+
 ## Sync modes
 
 `--global-aws-orgs-enabled` can be set on its own: the connector discovers every account in the AWS Organization and assumes a role into each one to sync its IAM users, roles, and groups. `--global-aws-sso-enabled` requires `--global-aws-orgs-enabled` to also be set; with both on, the connector syncs Identity Center users, groups, permission sets, and account assignments from the management account (or a delegated administrator account).
@@ -165,6 +179,18 @@ _These policies have comments prefixed with // that need to be removed before us
     },
     {
       "Action": [
+        "organizations:ListRoots",
+        "organizations:ListOrganizationalUnitsForParent"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      // Optional: only needed for the Sparse ACLs Organization Root / Organizational Unit hierarchy.
+      // Requires --global-aws-orgs-enabled and --global-aws-sso-enabled, plus tenant opt-in in the C1 UI.
+      // If omitted, the connector logs a warning and skips the OU hierarchy (accounts stay flat).
+      "Sid": "SparseACLOrganizationHierarchy"
+    },
+    {
+      "Action": [
         "sts:AssumeRole"
       ],
       "Effect": "Allow",
@@ -276,6 +302,18 @@ _These policies have comments prefixed with // that need to be removed before us
       // Without this, the connector will attempt assignments and may get unclear ConflictException errors
       // for suspended accounts. This permission provides clearer error messages.
       "Sid": "AccountStatusValidationForProvisioning"
+    },
+    {
+      "Action": [
+        "organizations:ListRoots",
+        "organizations:ListOrganizationalUnitsForParent"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      // Optional: only needed for the Sparse ACLs Organization Root / Organizational Unit hierarchy.
+      // Requires --global-aws-orgs-enabled and --global-aws-sso-enabled, plus tenant opt-in in the C1 UI.
+      // If omitted, the connector logs a warning and skips the OU hierarchy (accounts stay flat).
+      "Sid": "SparseACLOrganizationHierarchy"
     },
     {
       "Action": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -36,7 +36,7 @@ The AWS connector supports [automatic account provisioning and deprovisioning](/
 
 ## Sparse ACLs: Organizations and permission sets as scoped bindings
 
-When both **Enable support for AWS Organizations** and **Enable support for AWS IAM Identity Center** are turned on, the connector can additionally model Identity Center permission set assignments as **Sparse ACL** bindings, alongside the existing flat per-account entitlement model. This introduces four resource types:
+When both **Enable support for AWS Organizations** and **Enable support for AWS IAM Identity Center** are turned on, the connector also models Identity Center permission set assignments as **Sparse ACL** bindings, alongside the existing flat per-account entitlement model. This introduces four resource types:
 
 - **Organization Root** and **Organizational Unit** — the AWS Organizations hierarchy (Root → OU → Account), synced as read-only navigation/review context. Neither carries bindings of its own.
 - **Permission Set** — a role catalog entry for each Identity Center permission set.
@@ -44,9 +44,9 @@ When both **Enable support for AWS Organizations** and **Enable support for AWS 
 
 Instead of one row per (account, permission set, user) combination, reviewers see "Permission Set X on Account Y" as a single item, with the account's place in the AWS Organizations hierarchy shown for context.
 
-These four resource types are **opt-in** on the C1 platform: even with both checkboxes enabled above, an administrator must separately opt in to each resource type before C1 begins syncing it. Until you opt in, the connector keeps syncing the existing flat account/permission-set entitlement model unchanged.
+These four resource types are **opt-in** on the C1 platform: even with both checkboxes enabled above, you must separately opt in to each resource type before C1 begins syncing it. Until you opt in, the connector keeps syncing the existing flat account/permission-set entitlement model unchanged.
 
-Syncing the Organization Root / Organizational Unit hierarchy additionally requires the `organizations:ListRoots` and `organizations:ListOrganizationalUnitsForParent` permissions (see the IAM policy in the Identity Center setup tab below). If these permissions are missing, the connector logs a warning and skips the OU hierarchy rather than failing the sync — accounts continue to sync without OU grouping.
+Syncing the Organization Root / Organizational Unit hierarchy also requires the `organizations:ListRoots` and `organizations:ListOrganizationalUnitsForParent` permissions (see the IAM policy in the Identity Center setup tab below). If these permissions are missing, the connector logs a warning and skips the OU hierarchy rather than failing the sync — accounts continue to sync without OU grouping.
 
 ## Gather AWS credentials
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -23,12 +23,30 @@ If you're setting up AWS with C1 for the first time, you're in the right place.
 | Identity Center groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Accounts via Permission Sets | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>\* |
 | Secrets - Access keys | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Organization Root / Organizational Unit (Sparse ACLs)\*\* | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Permission Set / Permission Set Assignment (Sparse ACLs)\*\* | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>\* |
 
 The AWS connector supports [automatic account provisioning and deprovisioning](/product/admin/account-provisioning) of IAM accounts.
 
 \*The connector can provision to accounts via permissions sets only if Identity Center is enabled.
 
+\*\*Sparse ACL resources are opt-in — see [Sparse ACLs: Organizations and permission sets as scoped bindings](#sparse-acls-organizations-and-permission-sets-as-scoped-bindings) below.
+
 [This connector can sync secrets](/product/admin/inventory) and display them on the **Inventory** page.
+
+## Sparse ACLs: Organizations and permission sets as scoped bindings
+
+When both **Enable support for AWS Organizations** and **Enable support for AWS IAM Identity Center** are turned on, the connector can additionally model Identity Center permission set assignments as **Sparse ACL** bindings, alongside the existing flat per-account entitlement model. This introduces four resource types:
+
+- **Organization Root** and **Organizational Unit** — the AWS Organizations hierarchy (Root → OU → Account), synced as read-only navigation/review context. Neither carries bindings of its own.
+- **Permission Set** — a role catalog entry for each Identity Center permission set.
+- **Permission Set Assignment** — one binding per (permission set, account) pair that's actually assigned, listing the users and groups granted that permission set on that account. Group grants expand to their members.
+
+Instead of one row per (account, permission set, user) combination, reviewers see "Permission Set X on Account Y" as a single item, with the account's place in the AWS Organizations hierarchy shown for context.
+
+These four resource types are **opt-in** on the C1 platform: even with both checkboxes enabled above, an administrator must separately opt in to each resource type before C1 begins syncing it. Until you opt in, the connector keeps syncing the existing flat account/permission-set entitlement model unchanged.
+
+Syncing the Organization Root / Organizational Unit hierarchy additionally requires the `organizations:ListRoots` and `organizations:ListOrganizationalUnitsForParent` permissions (see the IAM policy in the Identity Center setup tab below). If these permissions are missing, the connector logs a warning and skips the OU hierarchy rather than failing the sync — accounts continue to sync without OU grouping.
 
 ## Gather AWS credentials
 
@@ -350,6 +368,8 @@ The permissions policy below is broken into several sections to align with these
 	        "sso:ListInstances",
 	        "sso:ListPermissionSets",
 	        "sso:ListPermissionSetsProvisionedToAccount",
+	        "organizations:ListRoots",
+	        "organizations:ListOrganizationalUnitsForParent",
 	        "iam:GetUser",
 	        "iam:ListAccessKeys",
 	        "iam:ListSigningCertificates",
@@ -446,6 +466,7 @@ The permissions policy below is broken into several sections to align with these
 	- `identitystore:List...`: These permissions are specific to AWS IAM Identity Center. They allow C1 to list and read information about your users and groups as they are defined within the Identity Center.
 	- `organizations:ListAccounts`: This permission is required to list all the accounts within your AWS Organization, enabling C1 to understand your account structure.
 	- `sso:List..., sso:Describe...`: These permissions allow C1 to list your permission sets and see how they are assigned to accounts and users.
+	- `organizations:ListRoots, organizations:ListOrganizationalUnitsForParent`: **Optional**, only needed for the Sparse ACLs Organization Root / Organizational Unit hierarchy (see [Sparse ACLs](#sparse-acls-organizations-and-permission-sets-as-scoped-bindings) above). If omitted, the connector logs a warning and skips the OU hierarchy instead of failing.
 	- `iam:GetUser, and various iam:List... permissions`: These permissions are necessary for C1 to first retrieve all associated credentials and metadata for an IAM user before a complete deletion can be performed.
 	**Section 2: Provisioning access (“C1ProvisionAccess”)**
 	This group of permissions is only required if you want to provision (create or delete) user assignments in AWS, including managing IAM users directly. For example, if you plan to use C1 to add a user to a group, assign a permission set to a user, create an IAM user, or fully delete an IAM user, you will need to include these permissions.


### PR DESCRIPTION
Explain the new Organization/Organizational Unit and Permission Set/ Permission Set Assignment resources, their dual activation gate (orgs+sso flags plus platform opt-in), and the additional organizations:ListRoots/ListOrganizationalUnitsForParent permissions.