### PR TITLE
CXP-756 Attach ChildResourceType to emitted org/OU resource

### DIFF
--- a/pkg/connector/organization.go
+++ b/pkg/connector/organization.go
@@ -49,6 +49,12 @@ func organizationResource(root awsOrgsTypes.Root) (*v2.Resource, error) {
 		name,
 		resourceTypeOrganization,
 		awsSdk.ToString(root.Id),
+		// Sparse ACLs: the root is the crawl seed for the OU tree — this annotation is
+		// what the SDK actually reads to schedule the organizational_unit child sync
+		// (a ResourceType-level annotation alone does not drive dispatch).
+		resourceSdk.WithAnnotation(&v2.ChildResourceType{
+			ResourceTypeId: resourceTypeOrganizationalUnit.Id,
+		}),
 	)
 }
 
@@ -139,13 +145,18 @@ func organizationalUnitResource(ou awsOrgsTypes.OrganizationalUnit, parentResour
 		resourceTypeOrganizationalUnit,
 		awsSdk.ToString(ou.Id),
 		resourceSdk.WithParentResourceID(parentResourceID),
+		// Nested OUs: self-referencing child type so the SDK recurses into sub-OUs.
+		resourceSdk.WithAnnotation(&v2.ChildResourceType{
+			ResourceTypeId: resourceTypeOrganizationalUnit.Id,
+		}),
 	)
 }
 
 func (o *organizationalUnitResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
 	// OUs only exist beneath a root or another OU; they are never a top-level resource. Crawl
 	// only when listed as a child of one of those tiers (the SDK drives this via the
-	// ChildResourceType annotations on organization / organizational_unit).
+	// ChildResourceType annotation each organization/organizational_unit resource attaches
+	// to itself — see organizationResource / organizationalUnitResource).
 	if parentResourceID == nil ||
 		(parentResourceID.ResourceType != resourceTypeOrganization.Id &&
 			parentResourceID.ResourceType != resourceTypeOrganizationalUnit.Id) {

--- a/pkg/connector/organization_test.go
+++ b/pkg/connector/organization_test.go
@@ -9,6 +9,7 @@ import (
 	awsOrgsTypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,41 @@ func TestOrganizationList_EmitsRoots(t *testing.T) {
 	assert.Equal(t, resourceTypeOrganization.Id, resources[0].Id.ResourceType)
 	assert.Equal(t, testRootID, resources[0].Id.Resource)
 	assert.Nil(t, resources[0].ParentResourceId, "root is the top tier; no parent")
+}
+
+// organizationResource must attach a ChildResourceType annotation to the emitted resource
+// instance — this is what the SDK's syncer actually reads to schedule the organizational_unit
+// child crawl (a ResourceType-level annotation alone does not drive dispatch). Regression test
+// for CXP-756, where this was missing and the OU tier silently never synced.
+func TestOrganizationResource_EmitsChildResourceTypeAnnotation(t *testing.T) {
+	r, err := organizationResource(awsOrgsTypes.Root{Id: awsSdk.String(testRootID)})
+	require.NoError(t, err)
+
+	annos := annotations.Annotations(r.GetAnnotations())
+	require.True(t, annos.Contains((*v2.ChildResourceType)(nil)))
+
+	var crt v2.ChildResourceType
+	ok, err := annos.Pick(&crt)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, resourceTypeOrganizationalUnit.Id, crt.ResourceTypeId)
+}
+
+// organizationalUnitResource must attach a ChildResourceType annotation pointing at itself so
+// the SDK recurses into nested OUs. Regression test for CXP-756.
+func TestOrganizationalUnitResource_EmitsChildResourceTypeAnnotation(t *testing.T) {
+	parent := &v2.ResourceId{ResourceType: resourceTypeOrganization.Id, Resource: testRootID}
+	r, err := organizationalUnitResource(awsOrgsTypes.OrganizationalUnit{Id: awsSdk.String(testOUID)}, parent)
+	require.NoError(t, err)
+
+	annos := annotations.Annotations(r.GetAnnotations())
+	require.True(t, annos.Contains((*v2.ChildResourceType)(nil)))
+
+	var crt v2.ChildResourceType
+	ok, err := annos.Pick(&crt)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, resourceTypeOrganizationalUnit.Id, crt.ResourceTypeId)
 }
 
 // organization.List degrades to no hierarchy (no error) when org-read permission is missing.

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -229,15 +229,18 @@ var (
 	// of the Sparse ACLs hierarchy (Root → OU → Account). It holds no binding — AWS has no
 	// native Root-level permission-set assignment — and exists purely as navigation /
 	// by-inheritance review context. SkipEntitlementsAndGrants + OptInRequired, like Azure's
-	// management-group tier. The OU child-crawl is driven by a ChildResourceType annotation
-	// attached to each emitted resource instance (see organizationResource in organization.go),
-	// not by an annotation here — the syncer only reads instance-level annotations.
+	// management-group tier. The ChildResourceType annotation here feeds capabilities
+	// metadata generation; the actual OU child-crawl is driven by the matching annotation
+	// attached to each emitted resource instance (see organizationResource in
+	// organization.go) — the syncer only reads instance-level annotations for that.
 	resourceTypeOrganization = &v2.ResourceType{
 		Id:          "organization",
 		DisplayName: "Organization Root",
 		Annotations: annotations.New(
 			&v2.SkipEntitlementsAndGrants{},
 			&v2.OptInRequired{},
+			// The root is the crawl seed for the OU tree.
+			&v2.ChildResourceType{ResourceTypeId: "organizational_unit"},
 			capabilityPermissions(
 				"organizations:ListRoots",
 				"organizations:ListOrganizationalUnitsForParent",
@@ -247,8 +250,9 @@ var (
 
 	// resourceTypeOrganizationalUnit is an AWS Organizations OU, an intermediate scope tier
 	// between the root and accounts. Like the root it carries no binding (no native OU-level
-	// assignment) and is hierarchy/review context only. Nested-OU recursion is driven by a
-	// ChildResourceType annotation attached to each emitted resource instance (see
+	// assignment) and is hierarchy/review context only. It declares itself as a child type so
+	// capabilities metadata reflects nested-OU recursion; the actual recursion is driven by the
+	// matching annotation attached to each emitted resource instance (see
 	// organizationalUnitResource in organization.go). SkipEntitlementsAndGrants + OptInRequired.
 	resourceTypeOrganizationalUnit = &v2.ResourceType{
 		Id:          "organizational_unit",
@@ -256,6 +260,7 @@ var (
 		Annotations: annotations.New(
 			&v2.SkipEntitlementsAndGrants{},
 			&v2.OptInRequired{},
+			&v2.ChildResourceType{ResourceTypeId: "organizational_unit"},
 			capabilityPermissions(
 				"organizations:ListOrganizationalUnitsForParent",
 			),

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -229,15 +229,15 @@ var (
 	// of the Sparse ACLs hierarchy (Root → OU → Account). It holds no binding — AWS has no
 	// native Root-level permission-set assignment — and exists purely as navigation /
 	// by-inheritance review context. SkipEntitlementsAndGrants + OptInRequired, like Azure's
-	// management-group tier.
+	// management-group tier. The OU child-crawl is driven by a ChildResourceType annotation
+	// attached to each emitted resource instance (see organizationResource in organization.go),
+	// not by an annotation here — the syncer only reads instance-level annotations.
 	resourceTypeOrganization = &v2.ResourceType{
 		Id:          "organization",
 		DisplayName: "Organization Root",
 		Annotations: annotations.New(
 			&v2.SkipEntitlementsAndGrants{},
 			&v2.OptInRequired{},
-			// The root is the crawl seed for the OU tree.
-			&v2.ChildResourceType{ResourceTypeId: "organizational_unit"},
 			capabilityPermissions(
 				"organizations:ListRoots",
 				"organizations:ListOrganizationalUnitsForParent",
@@ -247,15 +247,15 @@ var (
 
 	// resourceTypeOrganizationalUnit is an AWS Organizations OU, an intermediate scope tier
 	// between the root and accounts. Like the root it carries no binding (no native OU-level
-	// assignment) and is hierarchy/review context only. It declares itself as a child type so
-	// the SDK recurses into nested OUs. SkipEntitlementsAndGrants + OptInRequired.
+	// assignment) and is hierarchy/review context only. Nested-OU recursion is driven by a
+	// ChildResourceType annotation attached to each emitted resource instance (see
+	// organizationalUnitResource in organization.go). SkipEntitlementsAndGrants + OptInRequired.
 	resourceTypeOrganizationalUnit = &v2.ResourceType{
 		Id:          "organizational_unit",
 		DisplayName: "Organizational Unit",
 		Annotations: annotations.New(
 			&v2.SkipEntitlementsAndGrants{},
 			&v2.OptInRequired{},
-			&v2.ChildResourceType{ResourceTypeId: "organizational_unit"},
 			capabilityPermissions(
 				"organizations:ListOrganizationalUnitsForParent",
 			),


### PR DESCRIPTION
The SDK's syncer schedules child-resource crawls by reading a ChildResourceType annotation off each emitted resource instance, not off the registered ResourceType. organizationResource() and organizationalUnitResource() only declared it on the ResourceType, so the OU crawl never fired: organizational_unit sync count was always 0, and accounts re-parented under an OU ended up with a dangling parent pointing at a resource that was never emitted.

Attach the annotation to each emitted org/OU resource instance, mirroring the working account.go -> permission_set_assignment pattern, and drop the now-dead (and misleading) annotation from the ResourceType definitions. Add regression tests asserting the annotation the syncer actually checks is present on emitted resources.