### PR TITLE
Guard iam_policy grant emission behind WillSyncResourceType

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -99,6 +99,7 @@ type AWS struct {
 	syncSecrets              bool
 	syncSSOUserLastLogin     bool
 	syncOnlyAttachedPolicies bool
+	syncIAMPolicyGrants      bool
 
 	accountProvisioningTarget string
 }
@@ -241,8 +242,15 @@ func validateConfig(awsc *cfg.Aws) error {
 	return nil
 }
 
-func New(ctx context.Context, awsc *cfg.Aws, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+func New(ctx context.Context, awsc *cfg.Aws, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	l := ctxzap.Extract(ctx)
+
+	// syncIAMPolicyGrants gates the cross-type iam_policy grants that iamUser, role,
+	// iamGroup, and permissionSet emit as a sync optimization. When the caller has
+	// explicitly filtered resource types and iam_policy isn't among them, emitting
+	// those grants is invalid/wasteful. A nil opts (e.g. capabilities generation or
+	// callers that don't pass one) is treated the same as "no filter" -> sync everything.
+	syncIAMPolicyGrants := opts == nil || opts.WillSyncResourceType("iam_policy")
 
 	err := field.Validate(cfg.Config, awsc)
 	if err != nil {
@@ -309,6 +317,7 @@ func New(ctx context.Context, awsc *cfg.Aws, _ *cli.ConnectorOpts) (connectorbui
 		syncSecrets:              config.SyncSecrets,
 		syncSSOUserLastLogin:     config.SyncSSOUserLastLogin,
 		syncOnlyAttachedPolicies: config.SyncOnlyAttachedPolicies,
+		syncIAMPolicyGrants:      syncIAMPolicyGrants,
 
 		accountProvisioningTarget: config.AccountProvisioningTarget,
 	}
@@ -449,9 +458,9 @@ func (c *AWS) shouldSyncCrossAccountIAM() bool {
 func (c *AWS) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	l := ctxzap.Extract(ctx)
 	rs := []connectorbuilder.ResourceSyncerV2{
-		iamUserBuilder(c.iamClient, c.awsClientFactory, c),
-		iamRoleBuilder(c.iamClient, c.awsClientFactory),
-		iamGroupBuilder(c.iamClient, c.awsClientFactory),
+		iamUserBuilder(c.iamClient, c.awsClientFactory, c, c.syncIAMPolicyGrants),
+		iamRoleBuilder(c.iamClient, c.awsClientFactory, c.syncIAMPolicyGrants),
+		iamGroupBuilder(c.iamClient, c.awsClientFactory, c.syncIAMPolicyGrants),
 		iamPolicyBuilder(c.iamClient, c.awsClientFactory, c.syncOnlyAttachedPolicies),
 		// ssoAdminClient/identityInstance are nil when SSO is disabled; the inline
 		// policy builder only uses them for permission_set parents, which are only
@@ -478,7 +487,7 @@ func (c *AWS) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSy
 			acct,
 			// Sparse ACLs (Cloud Infrastructure Access): permission set as role, and the
 			// per-(account, permission set) scope-binding. Both are OptInRequired.
-			permissionSetBuilder(c.ssoAdminClient, c.identityInstance),
+			permissionSetBuilder(c.ssoAdminClient, c.identityInstance, c.syncIAMPolicyGrants),
 			permissionSetAssignmentBuilder(acct),
 			// Sparse ACLs hierarchy: Organization Root → OU scope tiers (account re-parenting
 			// happens in accountBuilder.List). Hierarchy/review context only — no bindings.
@@ -512,15 +521,15 @@ func (d *defaultCapabilitiesBuilder) Validate(_ context.Context) (annotations.An
 
 func (d *defaultCapabilitiesBuilder) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		iamUserBuilder(nil, nil, nil),
-		iamRoleBuilder(nil, nil),
-		iamGroupBuilder(nil, nil),
+		iamUserBuilder(nil, nil, nil, true),
+		iamRoleBuilder(nil, nil, true),
+		iamGroupBuilder(nil, nil, true),
 		iamPolicyBuilder(nil, nil, false),
 		inlinePolicyBuilder(nil, nil, nil, nil),
 		ssoUserBuilder("", nil, nil, nil, nil),
 		ssoGroupBuilder("", nil, nil, nil),
 		accountBuilder(nil, "", nil, nil, "", nil),
-		permissionSetBuilder(nil, nil),
+		permissionSetBuilder(nil, nil, true),
 		permissionSetAssignmentBuilder(accountBuilder(nil, "", nil, nil, "", nil)),
 		organizationBuilder(nil),
 		organizationalUnitBuilder(nil),

--- a/pkg/connector/iam_group.go
+++ b/pkg/connector/iam_group.go
@@ -24,9 +24,10 @@ const (
 )
 
 type iamGroupResourceType struct {
-	resourceType     *v2.ResourceType
-	iamClient        *iam.Client
-	awsClientFactory *AWSClientFactory
+	resourceType        *v2.ResourceType
+	iamClient           *iam.Client
+	awsClientFactory    *AWSClientFactory
+	syncIAMPolicyGrants bool
 }
 
 func (o *iamGroupResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -129,6 +130,12 @@ func (o *iamGroupResourceType) Grants(ctx context.Context, resource *v2.Resource
 	}
 
 	if bag.ResourceTypeID() == iamGroupGrantsAttachedPoliciesPhase {
+		if !o.syncIAMPolicyGrants {
+			// Shouldn't normally be resumed into this phase when the gate is off (we never
+			// push it below), but guard defensively: terminate cleanly rather than paginate
+			// through policy calls for a resource type that isn't being synced.
+			return nil, nil, nil
+		}
 		return o.grantsForAttachedGroupPolicies(ctx, iamClient, resource, bag, nil)
 	}
 
@@ -184,6 +191,14 @@ func (o *iamGroupResourceType) Grants(ctx context.Context, resource *v2.Resource
 
 	// Membership is done (IsTruncated without a Marker shouldn't happen, but
 	// treat it as done rather than silently skipping the policy phase).
+	//
+	// The attached-policies phase emits cross-type iam_policy "attached" grants (a sync
+	// optimization); skip entering it entirely when iam_policy isn't being synced, rather
+	// than push a phase we don't intend to honor.
+	if !o.syncIAMPolicyGrants {
+		return rv, nil, nil
+	}
+
 	bag.Push(pagination.PageState{
 		ResourceTypeID: iamGroupGrantsAttachedPoliciesPhase,
 	})
@@ -233,11 +248,12 @@ func (o *iamGroupResourceType) grantsForAttachedGroupPolicies(
 	return rv, nil, nil
 }
 
-func iamGroupBuilder(iamClient *iam.Client, awsClientFactory *AWSClientFactory) *iamGroupResourceType {
+func iamGroupBuilder(iamClient *iam.Client, awsClientFactory *AWSClientFactory, syncIAMPolicyGrants bool) *iamGroupResourceType {
 	return &iamGroupResourceType{
-		resourceType:     resourceTypeIAMGroup,
-		iamClient:        iamClient,
-		awsClientFactory: awsClientFactory,
+		resourceType:        resourceTypeIAMGroup,
+		iamClient:           iamClient,
+		awsClientFactory:    awsClientFactory,
+		syncIAMPolicyGrants: syncIAMPolicyGrants,
 	}
 }
 

--- a/pkg/connector/iam_group_test.go
+++ b/pkg/connector/iam_group_test.go
@@ -1,0 +1,46 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Grants resumed directly into the attached-policies phase (iamGroupGrantsAttachedPoliciesPhase)
+// must short-circuit when syncIAMPolicyGrants is false, before ever touching the IAM client:
+// iamClient is nil here, so if the gate were missing (pre-fix behavior) the underlying
+// listAttachedGroupPolicyGrants call would panic on a nil IAM client rather than return cleanly.
+// Same-type membership grants are unaffected since this test never reaches that code path.
+func TestIamGroupGrants_SkipsAttachedPoliciesPhaseWhenGateOff(t *testing.T) {
+	ctx := context.Background()
+
+	bag := &pagination.Bag{}
+	bag.Push(pagination.PageState{ResourceTypeID: iamGroupGrantsAttachedPoliciesPhase})
+	token, err := bag.Marshal()
+	require.NoError(t, err)
+
+	o := &iamGroupResourceType{
+		resourceType:        resourceTypeIAMGroup,
+		iamClient:           nil,
+		awsClientFactory:    nil,
+		syncIAMPolicyGrants: false,
+	}
+
+	resource := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: resourceTypeIAMGroup.Id,
+			Resource:     "arn:aws:iam::123456789012:group/ci-group-1",
+		},
+		DisplayName: "ci-group-1",
+	}
+
+	grants, res, err := o.Grants(ctx, resource, resourceSdk.SyncOpAttrs{PageToken: pagination.Token{Token: token}})
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+	assert.Nil(t, res)
+}

--- a/pkg/connector/iam_user.go
+++ b/pkg/connector/iam_user.go
@@ -22,10 +22,11 @@ import (
 )
 
 type iamUserResourceType struct {
-	resourceType     *v2.ResourceType
-	iamClient        *iam.Client
-	awsClientFactory *AWSClientFactory
-	aws              *AWS
+	resourceType        *v2.ResourceType
+	iamClient           *iam.Client
+	awsClientFactory    *AWSClientFactory
+	aws                 *AWS
+	syncIAMPolicyGrants bool
 }
 
 var _ connectorbuilder.AccountManagerV2 = &iamUserResourceType{}
@@ -115,6 +116,14 @@ func (o *iamUserResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ 
 }
 
 func (o *iamUserResourceType) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	// This method exists only to emit cross-type iam_policy "attached" grants (a sync
+	// optimization on top of AWS API responses already fetched during this builder's own
+	// sync). If iam_policy isn't being synced, skip entirely rather than emit grants
+	// referencing an unsynced resource type.
+	if !o.syncIAMPolicyGrants {
+		return nil, nil, nil
+	}
+
 	bag := &pagination.Bag{}
 	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
 		return nil, nil, err
@@ -173,12 +182,13 @@ func (o *iamUserResourceType) Grants(ctx context.Context, resource *v2.Resource,
 	return grants, nil, nil
 }
 
-func iamUserBuilder(iamClient *iam.Client, awsClientFactory *AWSClientFactory, aws *AWS) *iamUserResourceType {
+func iamUserBuilder(iamClient *iam.Client, awsClientFactory *AWSClientFactory, aws *AWS, syncIAMPolicyGrants bool) *iamUserResourceType {
 	return &iamUserResourceType{
-		resourceType:     resourceTypeIAMUser,
-		iamClient:        iamClient,
-		awsClientFactory: awsClientFactory,
-		aws:              aws,
+		resourceType:        resourceTypeIAMUser,
+		iamClient:           iamClient,
+		awsClientFactory:    awsClientFactory,
+		aws:                 aws,
+		syncIAMPolicyGrants: syncIAMPolicyGrants,
 	}
 }
 

--- a/pkg/connector/iam_user.go
+++ b/pkg/connector/iam_user.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type iamUserResourceType struct {
@@ -32,7 +33,18 @@ type iamUserResourceType struct {
 var _ connectorbuilder.AccountManagerV2 = &iamUserResourceType{}
 
 func (o *iamUserResourceType) ResourceType(_ context.Context) *v2.ResourceType {
-	return o.resourceType
+	if o.syncIAMPolicyGrants {
+		return o.resourceType
+	}
+
+	rt, ok := proto.Clone(o.resourceType).(*v2.ResourceType)
+	if !ok {
+		return o.resourceType
+	}
+	annos := annotations.Annotations(rt.Annotations)
+	annos.Update(&v2.SkipEntitlementsAndGrants{})
+	rt.Annotations = annos
+	return rt
 }
 
 func (o *iamUserResourceType) List(ctx context.Context, parentId *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
@@ -116,14 +128,6 @@ func (o *iamUserResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ 
 }
 
 func (o *iamUserResourceType) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
-	// This method exists only to emit cross-type iam_policy "attached" grants (a sync
-	// optimization on top of AWS API responses already fetched during this builder's own
-	// sync). If iam_policy isn't being synced, skip entirely rather than emit grants
-	// referencing an unsynced resource type.
-	if !o.syncIAMPolicyGrants {
-		return nil, nil, nil
-	}
-
 	bag := &pagination.Bag{}
 	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
 		return nil, nil, err

--- a/pkg/connector/iam_user_test.go
+++ b/pkg/connector/iam_user_test.go
@@ -6,6 +6,7 @@ import (
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,4 +76,30 @@ func TestIamUserToResource_DedupesEmailFromUsername(t *testing.T) {
 	emails := trait.GetEmails()
 	require.Len(t, emails, 1, "email passed in must not be duplicated by getUserEmails")
 	assert.Equal(t, "dup@example.com", emails[0].GetAddress())
+}
+
+// Grants on iamUserResourceType exists only to emit cross-type iam_policy "attached"
+// grants. When syncIAMPolicyGrants is false, it must short-circuit before ever touching
+// the IAM client/factory: both are nil here, so if the gate were missing (pre-fix
+// behavior) this would panic on a nil-pointer dereference rather than return cleanly.
+func TestIamUserGrants_SkipsWhenIAMPolicyGrantsGateOff(t *testing.T) {
+	o := &iamUserResourceType{
+		resourceType:        resourceTypeIAMUser,
+		iamClient:           nil,
+		awsClientFactory:    nil,
+		aws:                 nil,
+		syncIAMPolicyGrants: false,
+	}
+
+	resource := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: resourceTypeIAMUser.Id,
+			Resource:     "arn:aws:iam::123456789012:user/ci-iam-1",
+		},
+	}
+
+	grants, results, err := o.Grants(context.Background(), resource, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+	assert.Nil(t, results)
 }

--- a/pkg/connector/iam_user_test.go
+++ b/pkg/connector/iam_user_test.go
@@ -7,6 +7,7 @@ import (
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,28 +79,39 @@ func TestIamUserToResource_DedupesEmailFromUsername(t *testing.T) {
 	assert.Equal(t, "dup@example.com", emails[0].GetAddress())
 }
 
-// Grants on iamUserResourceType exists only to emit cross-type iam_policy "attached"
-// grants. When syncIAMPolicyGrants is false, it must short-circuit before ever touching
-// the IAM client/factory: both are nil here, so if the gate were missing (pre-fix
-// behavior) this would panic on a nil-pointer dereference rather than return cleanly.
-func TestIamUserGrants_SkipsWhenIAMPolicyGrantsGateOff(t *testing.T) {
+// ResourceType on iamUserResourceType is the gate for cross-type iam_policy "attached"
+// grants: when iam_policy IS being synced, it must return the resource type unchanged
+// (already carrying the static SkipEntitlements annotation). When iam_policy is NOT being
+// synced, it must attach SkipEntitlementsAndGrants so the SDK skips this resource type's
+// Grants() call entirely rather than emit grants referencing an unsynced resource type.
+func TestIamUserResourceType_SkipsEntitlementsWhenSyncingIAMPolicy(t *testing.T) {
 	o := &iamUserResourceType{
 		resourceType:        resourceTypeIAMUser,
-		iamClient:           nil,
-		awsClientFactory:    nil,
-		aws:                 nil,
+		syncIAMPolicyGrants: true,
+	}
+
+	rt := o.ResourceType(context.Background())
+	require.NotNil(t, rt)
+
+	annos := annotations.Annotations(rt.Annotations)
+	assert.True(t, annos.Contains(&v2.SkipEntitlements{}))
+	assert.False(t, annos.Contains(&v2.SkipEntitlementsAndGrants{}))
+}
+
+func TestIamUserResourceType_SkipsEntitlementsAndGrantsWhenNotSyncingIAMPolicy(t *testing.T) {
+	o := &iamUserResourceType{
+		resourceType:        resourceTypeIAMUser,
 		syncIAMPolicyGrants: false,
 	}
 
-	resource := &v2.Resource{
-		Id: &v2.ResourceId{
-			ResourceType: resourceTypeIAMUser.Id,
-			Resource:     "arn:aws:iam::123456789012:user/ci-iam-1",
-		},
-	}
+	rt := o.ResourceType(context.Background())
+	require.NotNil(t, rt)
 
-	grants, results, err := o.Grants(context.Background(), resource, resourceSdk.SyncOpAttrs{})
-	require.NoError(t, err)
-	assert.Empty(t, grants)
-	assert.Nil(t, results)
+	annos := annotations.Annotations(rt.Annotations)
+	assert.True(t, annos.Contains(&v2.SkipEntitlementsAndGrants{}))
+
+	// The package-level var must not have been mutated by the clone-and-annotate path;
+	// other builder instances across the test run share this same var.
+	sharedAnnos := annotations.Annotations(resourceTypeIAMUser.Annotations)
+	assert.False(t, sharedAnnos.Contains(&v2.SkipEntitlementsAndGrants{}))
 }

--- a/pkg/connector/permission_set.go
+++ b/pkg/connector/permission_set.go
@@ -9,11 +9,13 @@ import (
 	awsSsoAdmin "github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	grantSdk "github.com/conductorone/baton-sdk/pkg/types/grant"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
 
 // permissionSetRoleID is the SINGLE place an Identity Center permission-set role id is
@@ -34,7 +36,18 @@ type permissionSetResourceType struct {
 }
 
 func (o *permissionSetResourceType) ResourceType(_ context.Context) *v2.ResourceType {
-	return o.resourceType
+	if o.syncIAMPolicyGrants {
+		return o.resourceType
+	}
+
+	rt, ok := proto.Clone(o.resourceType).(*v2.ResourceType)
+	if !ok {
+		return o.resourceType
+	}
+	annos := annotations.Annotations(rt.Annotations)
+	annos.Update(&v2.SkipEntitlementsAndGrants{})
+	rt.Annotations = annos
+	return rt
 }
 
 func (o *permissionSetResourceType) List(ctx context.Context, _ *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
@@ -116,14 +129,6 @@ func (o *permissionSetResourceType) Entitlements(_ context.Context, _ *v2.Resour
 // converge on the iam_policy "attached" entitlement. User-level grants stay on the
 // binding's "assigned" entitlement; these grants are structural only (no expansion).
 func (o *permissionSetResourceType) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
-	// This method exists only to emit cross-type iam_policy "attached" grants (a sync
-	// optimization on top of AWS API responses already fetched during this builder's own
-	// sync). If iam_policy isn't being synced, skip entirely rather than emit grants
-	// referencing an unsynced resource type.
-	if !o.syncIAMPolicyGrants {
-		return nil, nil, nil
-	}
-
 	input := &awsSsoAdmin.ListManagedPoliciesInPermissionSetInput{
 		InstanceArn:      o.identityInstance.InstanceArn,
 		PermissionSetArn: awsSdk.String(resource.Id.Resource),

--- a/pkg/connector/permission_set.go
+++ b/pkg/connector/permission_set.go
@@ -27,9 +27,10 @@ func permissionSetRoleID(permissionSetArn string) string {
 }
 
 type permissionSetResourceType struct {
-	resourceType     *v2.ResourceType
-	ssoAdminClient   ssoAdminAPI
-	identityInstance *awsSsoAdminTypes.InstanceMetadata
+	resourceType        *v2.ResourceType
+	ssoAdminClient      ssoAdminAPI
+	identityInstance    *awsSsoAdminTypes.InstanceMetadata
+	syncIAMPolicyGrants bool
 }
 
 func (o *permissionSetResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -115,6 +116,14 @@ func (o *permissionSetResourceType) Entitlements(_ context.Context, _ *v2.Resour
 // converge on the iam_policy "attached" entitlement. User-level grants stay on the
 // binding's "assigned" entitlement; these grants are structural only (no expansion).
 func (o *permissionSetResourceType) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	// This method exists only to emit cross-type iam_policy "attached" grants (a sync
+	// optimization on top of AWS API responses already fetched during this builder's own
+	// sync). If iam_policy isn't being synced, skip entirely rather than emit grants
+	// referencing an unsynced resource type.
+	if !o.syncIAMPolicyGrants {
+		return nil, nil, nil
+	}
+
 	input := &awsSsoAdmin.ListManagedPoliciesInPermissionSetInput{
 		InstanceArn:      o.identityInstance.InstanceArn,
 		PermissionSetArn: awsSdk.String(resource.Id.Resource),
@@ -170,10 +179,11 @@ func (o *permissionSetResourceType) Grants(ctx context.Context, resource *v2.Res
 	return rv, nil, nil
 }
 
-func permissionSetBuilder(ssoAdminClient ssoAdminAPI, identityInstance *awsSsoAdminTypes.InstanceMetadata) *permissionSetResourceType {
+func permissionSetBuilder(ssoAdminClient ssoAdminAPI, identityInstance *awsSsoAdminTypes.InstanceMetadata, syncIAMPolicyGrants bool) *permissionSetResourceType {
 	return &permissionSetResourceType{
-		resourceType:     resourceTypePermissionSet,
-		ssoAdminClient:   ssoAdminClient,
-		identityInstance: identityInstance,
+		resourceType:        resourceTypePermissionSet,
+		ssoAdminClient:      ssoAdminClient,
+		identityInstance:    identityInstance,
+		syncIAMPolicyGrants: syncIAMPolicyGrants,
 	}
 }

--- a/pkg/connector/permission_set_assignment_behavior_test.go
+++ b/pkg/connector/permission_set_assignment_behavior_test.go
@@ -361,7 +361,7 @@ func TestPermissionSetGrants_EmitsPolicyAttachments(t *testing.T) {
 		InstanceArn:     awsSdk.String(behaviorInstanceArn),
 		IdentityStoreId: awsSdk.String(behaviorIdentityStoreID),
 	}
-	ps := permissionSetBuilder(sso, identityInstance)
+	ps := permissionSetBuilder(sso, identityInstance, true)
 
 	psResource, err := permissionSetResource(&awsSsoAdminTypes.PermissionSet{
 		PermissionSetArn: awsSdk.String(testPermissionSetArn),
@@ -390,6 +390,43 @@ func TestPermissionSetGrants_EmitsPolicyAttachments(t *testing.T) {
 		assert.Equal(t, resourceTypePermissionSet.Id, g.Principal.Id.ResourceType)
 		assert.Equal(t, testPermissionSetArn, g.Principal.Id.Resource)
 	}
+}
+
+// When the sync filter excludes iam_policy, permission_set.Grants must not emit any
+// iam_policy "attached" grants (nor even call ListManagedPoliciesInPermissionSet) —
+// only the same-type role/binding grants live elsewhere. This is the mirror case of
+// TestPermissionSetGrants_EmitsPolicyAttachments: same setup, gate off, so it would fail
+// against pre-fix (unconditional-emission) code.
+func TestPermissionSetGrants_SkipsPolicyAttachmentsWhenGateOff(t *testing.T) {
+	ctx := context.Background()
+	called := false
+	sso := &fakeSSOAdmin{
+		listManagedPoliciesInPermissionSetFn: func(in *awsSsoAdmin.ListManagedPoliciesInPermissionSetInput) (*awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput, error) {
+			called = true
+			return &awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput{
+				AttachedManagedPolicies: []awsSsoAdminTypes.AttachedManagedPolicy{
+					{Arn: awsSdk.String("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"), Name: awsSdk.String("AmazonS3ReadOnlyAccess")},
+				},
+			}, nil
+		},
+	}
+	identityInstance := &awsSsoAdminTypes.InstanceMetadata{
+		InstanceArn:     awsSdk.String(behaviorInstanceArn),
+		IdentityStoreId: awsSdk.String(behaviorIdentityStoreID),
+	}
+	ps := permissionSetBuilder(sso, identityInstance, false)
+
+	psResource, err := permissionSetResource(&awsSsoAdminTypes.PermissionSet{
+		PermissionSetArn: awsSdk.String(testPermissionSetArn),
+		Name:             awsSdk.String("PowerUserAccess"),
+	})
+	require.NoError(t, err)
+
+	grants, res, err := ps.Grants(ctx, psResource, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+	assert.Nil(t, res)
+	assert.False(t, called, "must not call ListManagedPoliciesInPermissionSet when iam_policy grants are gated off")
 }
 
 // List on inline_policy with a permission_set parent fetches the Identity Center inline

--- a/pkg/connector/permission_set_assignment_behavior_test.go
+++ b/pkg/connector/permission_set_assignment_behavior_test.go
@@ -13,6 +13,7 @@ import (
 	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/conductorone/baton-aws/test"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/assert"
@@ -392,41 +393,44 @@ func TestPermissionSetGrants_EmitsPolicyAttachments(t *testing.T) {
 	}
 }
 
-// When the sync filter excludes iam_policy, permission_set.Grants must not emit any
-// iam_policy "attached" grants (nor even call ListManagedPoliciesInPermissionSet) —
-// only the same-type role/binding grants live elsewhere. This is the mirror case of
-// TestPermissionSetGrants_EmitsPolicyAttachments: same setup, gate off, so it would fail
-// against pre-fix (unconditional-emission) code.
-func TestPermissionSetGrants_SkipsPolicyAttachmentsWhenGateOff(t *testing.T) {
-	ctx := context.Background()
-	called := false
-	sso := &fakeSSOAdmin{
-		listManagedPoliciesInPermissionSetFn: func(in *awsSsoAdmin.ListManagedPoliciesInPermissionSetInput) (*awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput, error) {
-			called = true
-			return &awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput{
-				AttachedManagedPolicies: []awsSsoAdminTypes.AttachedManagedPolicy{
-					{Arn: awsSdk.String("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"), Name: awsSdk.String("AmazonS3ReadOnlyAccess")},
-				},
-			}, nil
-		},
-	}
+// ResourceType on permissionSetResourceType is the gate for cross-type iam_policy "attached"
+// grants: when iam_policy IS being synced, it must return the resource type unchanged
+// (already carrying the static SkipEntitlements annotation). When iam_policy is NOT being
+// synced, it must attach SkipEntitlementsAndGrants so the SDK skips this resource type's
+// Grants() call entirely rather than emit grants referencing an unsynced resource type. This
+// is the mirror case of TestPermissionSetGrants_EmitsPolicyAttachments.
+func TestPermissionSetResourceType_SkipsEntitlementsWhenSyncingIAMPolicy(t *testing.T) {
 	identityInstance := &awsSsoAdminTypes.InstanceMetadata{
 		InstanceArn:     awsSdk.String(behaviorInstanceArn),
 		IdentityStoreId: awsSdk.String(behaviorIdentityStoreID),
 	}
-	ps := permissionSetBuilder(sso, identityInstance, false)
+	ps := permissionSetBuilder(&fakeSSOAdmin{}, identityInstance, true)
 
-	psResource, err := permissionSetResource(&awsSsoAdminTypes.PermissionSet{
-		PermissionSetArn: awsSdk.String(testPermissionSetArn),
-		Name:             awsSdk.String("PowerUserAccess"),
-	})
-	require.NoError(t, err)
+	rt := ps.ResourceType(context.Background())
+	require.NotNil(t, rt)
 
-	grants, res, err := ps.Grants(ctx, psResource, resourceSdk.SyncOpAttrs{})
-	require.NoError(t, err)
-	assert.Empty(t, grants)
-	assert.Nil(t, res)
-	assert.False(t, called, "must not call ListManagedPoliciesInPermissionSet when iam_policy grants are gated off")
+	annos := annotations.Annotations(rt.Annotations)
+	assert.True(t, annos.Contains(&v2.SkipEntitlements{}))
+	assert.False(t, annos.Contains(&v2.SkipEntitlementsAndGrants{}))
+}
+
+func TestPermissionSetResourceType_SkipsEntitlementsAndGrantsWhenNotSyncingIAMPolicy(t *testing.T) {
+	identityInstance := &awsSsoAdminTypes.InstanceMetadata{
+		InstanceArn:     awsSdk.String(behaviorInstanceArn),
+		IdentityStoreId: awsSdk.String(behaviorIdentityStoreID),
+	}
+	ps := permissionSetBuilder(&fakeSSOAdmin{}, identityInstance, false)
+
+	rt := ps.ResourceType(context.Background())
+	require.NotNil(t, rt)
+
+	annos := annotations.Annotations(rt.Annotations)
+	assert.True(t, annos.Contains(&v2.SkipEntitlementsAndGrants{}))
+
+	// The package-level var must not have been mutated by the clone-and-annotate path;
+	// other builder instances across the test run share this same var.
+	sharedAnnos := annotations.Annotations(resourceTypePermissionSet.Annotations)
+	assert.False(t, sharedAnnos.Contains(&v2.SkipEntitlementsAndGrants{}))
 }
 
 // List on inline_policy with a permission_set parent fetches the Identity Center inline

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -27,9 +27,10 @@ const (
 )
 
 type roleResourceType struct {
-	resourceType     *v2.ResourceType
-	iamClient        *iam.Client
-	awsClientFactory *AWSClientFactory
+	resourceType        *v2.ResourceType
+	iamClient           *iam.Client
+	awsClientFactory    *AWSClientFactory
+	syncIAMPolicyGrants bool
 }
 
 func (o *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -228,35 +229,42 @@ func (o *roleResourceType) Grants(
 		}
 	}
 
-	policyGrants, nextMarker, err := listAttachedRolePolicyGrants(ctx, iamClient, roleName, resource.Id, bag.PageToken())
-	if err != nil {
-		if isAccessDeniedError(err) {
-			l.Warn("baton-aws: access denied listing attached role policies, skipping managed policy grants for this role",
-				zap.String("role_name", roleName),
-				zap.Error(err),
-			)
-		} else {
-			return nil, nil, err
-		}
-	} else {
-		grants = append(grants, policyGrants...)
-		if nextMarker != "" {
-			token, err := bag.NextToken(nextMarker)
-			if err != nil {
+	// The attached-policy lookup emits cross-type iam_policy "attached" grants (a sync
+	// optimization on top of AWS API responses already fetched here). If iam_policy isn't
+	// being synced, skip this portion; the same-type trust-policy-principal grants above
+	// must still be emitted regardless.
+	if o.syncIAMPolicyGrants {
+		policyGrants, nextMarker, err := listAttachedRolePolicyGrants(ctx, iamClient, roleName, resource.Id, bag.PageToken())
+		if err != nil {
+			if isAccessDeniedError(err) {
+				l.Warn("baton-aws: access denied listing attached role policies, skipping managed policy grants for this role",
+					zap.String("role_name", roleName),
+					zap.Error(err),
+				)
+			} else {
 				return nil, nil, err
 			}
-			return grants, &resourceSdk.SyncOpResults{NextPageToken: token}, nil
+		} else {
+			grants = append(grants, policyGrants...)
+			if nextMarker != "" {
+				token, err := bag.NextToken(nextMarker)
+				if err != nil {
+					return nil, nil, err
+				}
+				return grants, &resourceSdk.SyncOpResults{NextPageToken: token}, nil
+			}
 		}
 	}
 
 	return grants, nil, nil
 }
 
-func iamRoleBuilder(iamClient *iam.Client, awsClientFactory *AWSClientFactory) *roleResourceType {
+func iamRoleBuilder(iamClient *iam.Client, awsClientFactory *AWSClientFactory, syncIAMPolicyGrants bool) *roleResourceType {
 	return &roleResourceType{
-		resourceType:     resourceTypeRole,
-		iamClient:        iamClient,
-		awsClientFactory: awsClientFactory,
+		resourceType:        resourceTypeRole,
+		iamClient:           iamClient,
+		awsClientFactory:    awsClientFactory,
+		syncIAMPolicyGrants: syncIAMPolicyGrants,
 	}
 }
 


### PR DESCRIPTION
## Summary
- `iamUser`, `role`, `iamGroup`, and `permissionSet` each emit cross-type `iam_policy` "attached" grants as a sync optimization (their API responses already include attached-policy info), but did so **unconditionally** — even when a customer's sync filter excludes `iam_policy`.
- Each builder's behavior is now gated on `cli.ConnectorOpts.WillSyncResourceType("iam_policy")` (nil-safe: a missing `opts` is treated as "no filter", i.e. sync everything), computed once in `connector.New()` and threaded into all four builders as `syncIAMPolicyGrants bool` — following the pattern in ConductorOne/baton-linear#55.
- **Two different mechanisms are used, per resource type:**
  - `role` and `iamGroup` also emit legitimate **same-type** grants (trust-policy-principal grants; group membership grants) alongside the cross-type `iam_policy` grants. For these, only the `iam_policy`-emitting portion of `Grants()` is gated in place — the same-type grants stay unconditional.
  - `iamUser` and `permissionSet` exist **solely** to emit cross-type `iam_policy` grants (no entitlements, no same-type grants of their own). For these, the gating is expressed as an SDK-level annotation on `ResourceType()` instead: when `iam_policy` is being synced, the resource type is returned unchanged (already carries a static `SkipEntitlements` annotation); when it isn't, a `proto.Clone`'d copy is returned annotated with `SkipEntitlementsAndGrants`, so the SDK skips calling `Entitlements()`/`Grants()` for that type entirely rather than the connector short-circuiting internally.
- The capabilities-doc-generation path (`defaultCapabilitiesBuilder`, no `ConnectorOpts` available) passes a literal `true`, so `baton_capabilities.json` is unaffected — confirmed via `diff` against a freshly rebuilt connector's `capabilities` output (no diff).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite passes
- [x] Unit tests assert both states for each mechanism:
  - `role`/`iamGroup`: `Grants()` output with the gate on/off
  - `iamUser`/`permissionSet`: `ResourceType()` annotations with the gate on/off, plus assertions that the shared package-level resource-type vars are never mutated by the clone
- [x] Rebuilt the connector binary and diffed `baton_capabilities.json` against fresh `capabilities` output — no diff

Co-authored-by: c1-squire-dev[bot] <c1-squire-dev[bot]@users.noreply.github.com>