### PR TITLE
CXP-832: declare ChildResourceType on the account resource type

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -52,6 +52,10 @@
             "id": "account"
           },
           {
+            "@type": "type.googleapis.com/c1.connector.v2.ChildResourceType",
+            "resourceTypeId": "permission_set_assignment"
+          },
+          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {

--- a/pkg/connector/account_resource_type_test.go
+++ b/pkg/connector/account_resource_type_test.go
@@ -1,0 +1,48 @@
+package connector
+
+import (
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resourceTypeAccount must declare a ChildResourceType annotation on the resource TYPE, pointing
+// at permission_set_assignment. The type-level annotation is what feeds capabilities metadata
+// generation (baton_capabilities.json); the emitted-resource annotation in account.go is what the
+// SDK syncer reads to dispatch the child crawl. Both are required.
+//
+// Regression test for CXP-832, where only the emitted-resource annotation existed, so the
+// generated capabilities under-reported the account -> permission_set_assignment child edge.
+// CXP-756 was the inverse omission on organization / organizational_unit.
+func TestResourceTypeAccount_DeclaresChildResourceTypeAnnotation(t *testing.T) {
+	annos := annotations.Annotations(resourceTypeAccount.GetAnnotations())
+	require.True(t, annos.Contains((*v2.ChildResourceType)(nil)),
+		"resourceTypeAccount must declare a type-level ChildResourceType annotation")
+
+	var crt v2.ChildResourceType
+	ok, err := annos.Pick(&crt)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, resourceTypePermissionSetAssignment.Id, crt.ResourceTypeId)
+}
+
+// The type-level declaration must not displace the annotations resourceTypeAccount already
+// carried: the v1 identifier (C1 backward-compat) and the capability permissions.
+func TestResourceTypeAccount_RetainsExistingAnnotations(t *testing.T) {
+	annos := annotations.Annotations(resourceTypeAccount.GetAnnotations())
+
+	var v1 v2.V1Identifier
+	ok, err := annos.Pick(&v1)
+	require.NoError(t, err)
+	require.True(t, ok, "resourceTypeAccount must retain its V1Identifier annotation")
+	assert.Equal(t, "account", v1.Id)
+
+	var perms v2.CapabilityPermissions
+	ok, err = annos.Pick(&perms)
+	require.NoError(t, err)
+	require.True(t, ok, "resourceTypeAccount must retain its CapabilityPermissions annotation")
+	assert.NotEmpty(t, perms.Permissions)
+}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -62,38 +62,48 @@ var (
 		Id:          "account", // this is "application" in c1
 		DisplayName: "Account",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP},
-		Annotations: v1AnnotationsWithPermissions("account", capabilityPermissions(
-			// Read
-			"organizations:ListAccounts",
-			"organizations:DescribeOrganization",
-			// Sparse ACLs hierarchy (Phase 2): resolve each account's parent (Root/OU) so
-			// c1's by-inheritance review can walk the org tree. Fail-soft if absent.
-			"organizations:ListParents",
-			"sso:ListPermissionSets",
-			"sso:DescribePermissionSet",
-			"sso:ListPermissionSetsProvisionedToAccount",
-			"sso:ListAccountAssignments",
-			"sso:ListInstances",
-			// Provision
-			"sso:CreateAccountAssignment",
-			"sso:DeleteAccountAssignment",
-			"sso:DescribeAccountAssignmentCreationStatus",
-			"sso:DescribeAccountAssignmentDeletionStatus",
-			// Supplemental: AWS-internal deps for SSO provisioning on SSO-provisioned roles
-			"iam:ListPolicies",
-			"iam:AttachRolePolicy",
-			"iam:CreateRole",
-			"iam:DeleteRole",
-			"iam:DeleteRolePolicy",
-			"iam:DetachRolePolicy",
-			"iam:GetRole",
-			"iam:ListAttachedRolePolicies",
-			"iam:ListRolePolicies",
-			"iam:PutRolePolicy",
-			"iam:UpdateRole",
-			"iam:UpdateRoleDescription",
-			"iam:GetSAMLProvider",
-		)),
+		Annotations: annotations.New(
+			&v2.V1Identifier{Id: "account"},
+			// Sparse ACLs: the per-(account, permission set) scope binding is a child of the
+			// account. This type-level annotation feeds capabilities metadata generation; the
+			// actual child crawl is dispatched by the matching annotation attached to each
+			// emitted account resource (see account.go). Both are required and must stay in
+			// sync — CXP-756 was the inverse omission, where only the type-level annotation
+			// existed and the SDK therefore never scheduled the child sync.
+			&v2.ChildResourceType{ResourceTypeId: resourceTypePermissionSetAssignment.Id},
+			capabilityPermissions(
+				// Read
+				"organizations:ListAccounts",
+				"organizations:DescribeOrganization",
+				// Sparse ACLs hierarchy (Phase 2): resolve each account's parent (Root/OU) so
+				// c1's by-inheritance review can walk the org tree. Fail-soft if absent.
+				"organizations:ListParents",
+				"sso:ListPermissionSets",
+				"sso:DescribePermissionSet",
+				"sso:ListPermissionSetsProvisionedToAccount",
+				"sso:ListAccountAssignments",
+				"sso:ListInstances",
+				// Provision
+				"sso:CreateAccountAssignment",
+				"sso:DeleteAccountAssignment",
+				"sso:DescribeAccountAssignmentCreationStatus",
+				"sso:DescribeAccountAssignmentDeletionStatus",
+				// Supplemental: AWS-internal deps for SSO provisioning on SSO-provisioned roles
+				"iam:ListPolicies",
+				"iam:AttachRolePolicy",
+				"iam:CreateRole",
+				"iam:DeleteRole",
+				"iam:DeleteRolePolicy",
+				"iam:DetachRolePolicy",
+				"iam:GetRole",
+				"iam:ListAttachedRolePolicies",
+				"iam:ListRolePolicies",
+				"iam:PutRolePolicy",
+				"iam:UpdateRole",
+				"iam:UpdateRoleDescription",
+				"iam:GetSAMLProvider",
+			),
+		),
 	}
 	resourceTypeAccountIam = &v2.ResourceType{
 		Id:          "account_iam",


### PR DESCRIPTION
## What

`baton-aws` declared the account → `permission_set_assignment` child edge only on the *emitted* account resource, not on the `account` resource **type**, so the generated `baton_capabilities.json` omitted it while listing the equivalent relationship for `organization` and `organizational_unit`.

Fixes CXP-832.

## Why there was no functional impact

The SDK syncer dispatches child crawls from **instance-level** annotations — `syncer.hasChildResources` reads `resource.GetAnnotations()` — and that annotation was already present at `pkg/connector/account.go:185`. Verified on v0.4.3: a full sync emits `resource_type_id=permission_set_assignment count=3`, each parented to its account. The gap was confined to capabilities metadata.

This is the **inverse** of CXP-756, where the annotation existed on the resource type but was missing from the emitted resource — and there the consequence was severe, because the SDK never scheduled the child sync and the OU tier silently never appeared. Same duality, opposite side, much smaller blast radius.

## Changes

- **`pkg/connector/resource_types.go`** — `resourceTypeAccount` now declares `ChildResourceType{permission_set_assignment}`, matching `resourceTypeOrganization` (`:236`) and `resourceTypeOrganizationalUnit` (`:257`), which carry it at both levels. Implemented with `annotations.New(...)` to match the pattern the sibling `resourceTypeAccountIam` already uses, rather than changing the shared `v1AnnotationsWithPermissions` helper that ten other resource types depend on.

  **Review hint:** most of this file's diff is re-indentation from that nesting. `git diff -w` reduces it to 9 semantic lines.

- **`baton_capabilities.json`** — regenerated with `./connector capabilities`. Exactly 4 lines added, in the same position the hierarchy types use (after `V1Identifier`, before `CapabilityPermissions`):

  ```json
  {
    "@type": "type.googleapis.com/c1.connector.v2.ChildResourceType",
    "resourceTypeId": "permission_set_assignment"
  }
  ```

- **`pkg/connector/account_resource_type_test.go`** — new regression tests, mirroring the ones PR #136 added for the hierarchy types:
  - `TestResourceTypeAccount_DeclaresChildResourceTypeAnnotation` — asserts the type-level annotation is present and points at `permission_set_assignment`.
  - `TestResourceTypeAccount_RetainsExistingAnnotations` — asserts the restructure did not displace the pre-existing `V1Identifier` or `CapabilityPermissions` annotations.

## Verification

- `gofmt -l` clean; `go build ./cmd/baton-aws` succeeds.
- Full suite green: `go test ./... -count=1`.
- **The regression test was confirmed to have teeth** — run against the pre-fix `resource_types.go` it fails with `resourceTypeAccount must declare a type-level ChildResourceType annotation`; it passes after the change.
- `baton_capabilities.json` diff inspected line by line: the only change is the added annotation, no unrelated regeneration churn.

## Notes

`v1AnnotationsWithPermissions` is left untouched and still used by the other resource types. `resourceTypePermissionSetAssignment.Id` is referenced rather than a string literal for compile-time safety; there is no initialization cycle, since `resourceTypePermissionSetAssignment` does not reference `resourceTypeAccount`, and the build confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
