### PR TITLE
fix(connector): refresh cross-account STS credentials instead of caching them forever

### DIFF
--- a/pkg/connector/aws_client_factory.go
+++ b/pkg/connector/aws_client_factory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
@@ -18,6 +19,14 @@ import (
 // crossAccountRoleSessionName identifies baton's cross-account sessions in the
 // target account's CloudTrail.
 const crossAccountRoleSessionName = "BatonCrossAccountSession"
+
+// crossAccountSessionDuration is explicit because stscreds defaults to 15 minutes rather
+// than inheriting the STS API's 1 hour; 1h is also the maximum role chaining permits.
+const crossAccountSessionDuration = time.Hour
+
+// crossAccountCredentialRefreshWindow re-assumes this far before real expiry, so no request
+// is signed with credentials that expire in flight (ExpiredToken is not retried).
+const crossAccountCredentialRefreshWindow = 5 * time.Minute
 
 type AWSClientFactory struct {
 	mutex sync.Mutex
@@ -53,14 +62,13 @@ func NewAWSClientFactory(config Config, aws *AWS, baseClient *http.Client) *AWSC
 // assumed-role credentials.
 //
 // The credentials MUST be refreshing rather than a one-shot AssumeRole wrapped in a
-// static provider: assumed-role sessions are capped at 1 hour (role chaining caps there,
-// and an AssumeRole call with no DurationSeconds defaults there anyway), while clients
-// built here are cached for the lifetime of the process and created eagerly at
-// account-listing time. Any sync where more than an hour elapses between creation and use
-// died mid-sync with `ExpiredToken`, and the cached client then failed every subsequent
-// sync until the process restarted. aws.NewCredentialsCache re-assumes on expiry, which
-// makes caching the client safe. This mirrors the connector's own credentials
-// (see (*AWS).getCallingConfig).
+// static provider: assumed-role sessions here last at most 1 hour (see
+// crossAccountSessionDuration), while clients built here are cached for the lifetime of
+// the process and created eagerly at account-listing time. Any sync where more than an
+// hour elapsed between creation and use died mid-sync with `ExpiredToken`, and the cached
+// client then failed every subsequent sync until the process restarted.
+// aws.NewCredentialsCache re-assumes on expiry, which makes caching the client safe. This
+// mirrors the connector's own credentials (see (*AWS).getCallingConfig).
 //
 // LoadDefaultConfig is retained deliberately: it is what lets child-account clients pick
 // up ambient AWS settings (retry mode/attempts, FIPS and dualstack via ConfigSources,
@@ -78,7 +86,11 @@ func (f *AWSClientFactory) getConfig(ctx context.Context, accountId string) (aws
 	creds := awsSdk.NewCredentialsCache(
 		stscreds.NewAssumeRoleProvider(stsClient, roleArn, func(aro *stscreds.AssumeRoleOptions) {
 			aro.RoleSessionName = crossAccountRoleSessionName
+			aro.Duration = crossAccountSessionDuration
 		}),
+		func(o *awsSdk.CredentialsCacheOptions) {
+			o.ExpiryWindow = crossAccountCredentialRefreshWindow
+		},
 	)
 
 	// stscreds providers are lazy — constructing one issues no API call. Retrieve once so

--- a/pkg/connector/aws_client_factory.go
+++ b/pkg/connector/aws_client_factory.go
@@ -8,12 +8,16 @@ import (
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awsOrgs "github.com/aws/aws-sdk-go-v2/service/organizations"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
+
+// crossAccountRoleSessionName identifies baton's cross-account sessions in the
+// target account's CloudTrail.
+const crossAccountRoleSessionName = "BatonCrossAccountSession"
 
 type AWSClientFactory struct {
 	mutex sync.Mutex
@@ -21,6 +25,10 @@ type AWSClientFactory struct {
 	config     Config
 	baseClient *http.Client
 	aws        *AWS
+
+	// stsClientFn resolves the STS client used to assume into child accounts. It is a
+	// field so tests can inject a fake; production always uses (*AWS).getSTSClient.
+	stsClientFn func(ctx context.Context) (stscreds.AssumeRoleAPIClient, error)
 
 	// Map for accountId
 	iamClientMap map[string]*iam.Client
@@ -35,30 +43,53 @@ func NewAWSClientFactory(config Config, aws *AWS, baseClient *http.Client) *AWSC
 		iamClientMap: make(map[string]*iam.Client),
 		orgClientMap: make(map[string]*awsOrgs.Client),
 		aws:          aws,
+		stsClientFn: func(ctx context.Context) (stscreds.AssumeRoleAPIClient, error) {
+			return aws.getSTSClient(ctx)
+		},
 	}
 }
 
+// getConfig builds an aws config for a child account backed by auto-refreshing
+// assumed-role credentials.
+//
+// The credentials MUST be refreshing rather than a one-shot AssumeRole wrapped in a
+// static provider: assumed-role sessions are capped at 1 hour (role chaining caps there,
+// and an AssumeRole call with no DurationSeconds defaults there anyway), while clients
+// built here are cached for the lifetime of the process and created eagerly at
+// account-listing time. Any sync where more than an hour elapses between creation and use
+// died mid-sync with `ExpiredToken`, and the cached client then failed every subsequent
+// sync until the process restarted. aws.NewCredentialsCache re-assumes on expiry, which
+// makes caching the client safe. This mirrors the connector's own credentials
+// (see (*AWS).getCallingConfig).
+//
+// LoadDefaultConfig is retained deliberately: it is what lets child-account clients pick
+// up ambient AWS settings (retry mode/attempts, FIPS and dualstack via ConfigSources,
+// endpoint mode, app id). Hand-building an awsSdk.Config here would silently drop them.
 func (f *AWSClientFactory) getConfig(ctx context.Context, accountId string) (awsSdk.Config, error) {
 	l := ctxzap.Extract(ctx)
 
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, f.config.IamAssumeRoleName)
 
-	stsClient, err := f.aws.getSTSClient(ctx)
+	stsClient, err := f.stsClientFn(ctx)
 	if err != nil {
 		return awsSdk.Config{}, fmt.Errorf("baton-aws: getSTSClient failed: %w", err)
 	}
 
-	output, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
-		RoleArn:         awsSdk.String(roleArn),
-		RoleSessionName: awsSdk.String("BatonCrossAccountSession"),
-	})
+	creds := awsSdk.NewCredentialsCache(
+		stscreds.NewAssumeRoleProvider(stsClient, roleArn, func(aro *stscreds.AssumeRoleOptions) {
+			aro.RoleSessionName = crossAccountRoleSessionName
+		}),
+	)
 
-	if err != nil {
+	// stscreds providers are lazy — constructing one issues no API call. Retrieve once so
+	// this still reports whether the role is assumable at all, which callers rely on to
+	// skip inaccessible accounts (see accountIAMResourceType.parseAssumeRole).
+	if _, err := creds.Retrieve(ctx); err != nil {
 		l.Warn("Failed to assume role", zap.Error(err), zap.String("roleArn", roleArn))
 		return awsSdk.Config{}, err
 	}
 
-	opts := GetAwsConfigOptionsForAssumeRole(output, f.baseClient, f.config)
+	opts := GetAwsConfigOptionsForCredentials(creds, f.baseClient, f.config)
 
 	baseConfig, err := awsConfig.LoadDefaultConfig(ctx, opts...)
 	if err != nil {

--- a/pkg/connector/aws_client_factory_test.go
+++ b/pkg/connector/aws_client_factory_test.go
@@ -1,0 +1,293 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	awsIam "github.com/aws/aws-sdk-go-v2/service/iam"
+	awsOrgs "github.com/aws/aws-sdk-go-v2/service/organizations"
+	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	stsTypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSTSClient records AssumeRole calls and returns queued responses. Credentials
+// expire after expiresIn so a CredentialsCache is forced to re-assume.
+type fakeSTSClient struct {
+	mu        sync.Mutex
+	calls     int
+	expiresIn time.Duration
+	// errAfter, when > 0, makes every call at or beyond that ordinal fail with err.
+	errAfter int
+	err      error
+}
+
+func (f *fakeSTSClient) AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+
+	if f.errAfter > 0 && f.calls >= f.errAfter {
+		return nil, f.err
+	}
+
+	return &sts.AssumeRoleOutput{Credentials: fakeCredentials(f.expiresIn)}, nil
+}
+
+func (f *fakeSTSClient) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func fakeCredentials(expiresIn time.Duration) *stsTypes.Credentials {
+	return &stsTypes.Credentials{
+		AccessKeyId:     awsSdk.String("AKIAFAKE"),
+		SecretAccessKey: awsSdk.String("secret"),
+		SessionToken:    awsSdk.String("token"),
+		Expiration:      awsSdk.Time(time.Now().Add(expiresIn)),
+	}
+}
+
+func newTestFactory(stsClient stscreds.AssumeRoleAPIClient) *AWSClientFactory {
+	return &AWSClientFactory{
+		mutex:        sync.Mutex{},
+		config:       Config{GlobalRegion: "us-east-1", IamAssumeRoleName: "BatonRole"},
+		baseClient:   http.DefaultClient,
+		iamClientMap: make(map[string]*awsIam.Client),
+		orgClientMap: make(map[string]*awsOrgs.Client),
+		stsClientFn: func(ctx context.Context) (stscreds.AssumeRoleAPIClient, error) {
+			return stsClient, nil
+		},
+	}
+}
+
+// TestGetConfigCredentialsRefreshOnExpiry is the regression test for CXP-801: the
+// credentials a cross-account client is built with must re-assume once the session
+// expires, instead of being frozen at creation time by a static provider.
+func TestGetConfigCredentialsRefreshOnExpiry(t *testing.T) {
+	ctx := context.Background()
+	// Already expired on arrival, so the second Retrieve must trigger a fresh AssumeRole.
+	fake := &fakeSTSClient{expiresIn: -time.Minute}
+	f := newTestFactory(fake)
+
+	cfg, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+	require.Equal(t, 1, fake.callCount(), "getConfig should probe assumability exactly once")
+
+	_, err = cfg.Credentials.Retrieve(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, fake.callCount(), "expired credentials must trigger a re-assume, not be served stale")
+}
+
+// TestGetConfigCredentialsCachedWhileValid guards the other direction: an unexpired
+// session must not re-assume on every request.
+func TestGetConfigCredentialsCachedWhileValid(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSTSClient{expiresIn: time.Hour}
+	f := newTestFactory(fake)
+
+	cfg, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+
+	for range 5 {
+		_, err = cfg.Credentials.Retrieve(ctx)
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, fake.callCount(), "valid credentials should be served from cache")
+}
+
+// TestGetConfigProbesAssumability covers what accountIAMResourceType.parseAssumeRole
+// relies on: an unassumable role must surface as an error from getConfig. stscreds
+// providers are lazy, so without the eager Retrieve this would silently succeed and the
+// account would fail later mid-crawl instead of being skipped.
+func TestGetConfigProbesAssumability(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSTSClient{
+		expiresIn: time.Hour,
+		errAfter:  1,
+		err:       stsAccessDenied(),
+	}
+	f := newTestFactory(fake)
+
+	_, err := f.getConfig(ctx, "123456789012")
+	require.Error(t, err, "getConfig must report a role it cannot assume")
+	require.Equal(t, 1, fake.callCount())
+}
+
+// TestGetConfigUsesStableSessionName keeps the CloudTrail session name intact.
+func TestGetConfigUsesStableSessionName(t *testing.T) {
+	ctx := context.Background()
+	rec := &sessionNameRecorder{expiresIn: time.Hour}
+	f := newTestFactory(rec)
+
+	_, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+	require.Equal(t, crossAccountRoleSessionName, rec.sessionName)
+}
+
+// TestGetConfigResolvesAmbientAWSSettings pins the behavior that makes getConfig go
+// through awsConfig.LoadDefaultConfig rather than hand-building an awsSdk.Config:
+// child-account clients must keep resolving ambient AWS settings. ConfigSources is the
+// load-bearing one — service clients read FIPS/dualstack and endpoint settings out of it
+// at construction, so an empty ConfigSources silently disables AWS_USE_FIPS_ENDPOINT for
+// cross-account clients.
+func TestGetConfigResolvesAmbientAWSSettings(t *testing.T) {
+	t.Setenv("AWS_RETRY_MODE", "adaptive")
+	t.Setenv("AWS_MAX_ATTEMPTS", "7")
+	t.Setenv("AWS_SDK_UA_APP_ID", "baton-aws-probe")
+
+	ctx := context.Background()
+	f := newTestFactory(&fakeSTSClient{expiresIn: time.Hour})
+
+	cfg, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+
+	require.Equal(t, awsSdk.RetryModeAdaptive, cfg.RetryMode, "AWS_RETRY_MODE must reach child-account clients")
+	require.Equal(t, 7, cfg.RetryMaxAttempts, "AWS_MAX_ATTEMPTS must reach child-account clients")
+	require.Equal(t, "baton-aws-probe", cfg.AppID)
+	require.NotEmpty(t, cfg.ConfigSources, "ConfigSources must be populated so FIPS/dualstack/endpoint settings resolve")
+
+	// The pinned fields must still win over anything ambient.
+	require.Equal(t, "us-east-1", cfg.Region)
+	require.Equal(t, http.DefaultClient, cfg.HTTPClient)
+}
+
+// TestGetConfigPreservesRefreshingCredentialsThroughLoadDefaultConfig guards the
+// interaction between the two halves of the fix: LoadDefaultConfig must hand back the
+// *awsSdk.CredentialsCache it was given rather than re-wrapping or replacing it, or the
+// refresh behavior would be silently lost on the way out.
+func TestGetConfigPreservesRefreshingCredentialsThroughLoadDefaultConfig(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeSTSClient{expiresIn: -time.Minute}
+	f := newTestFactory(fake)
+
+	cfg, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+	require.IsType(t, &awsSdk.CredentialsCache{}, cfg.Credentials,
+		"LoadDefaultConfig must pass the CredentialsCache through untouched")
+
+	before := fake.callCount()
+	_, err = cfg.Credentials.Retrieve(ctx)
+	require.NoError(t, err)
+	require.Greater(t, fake.callCount(), before,
+		"credentials returned by getConfig must still re-assume on expiry")
+}
+
+// TestGetConfigRoleARN verifies the assumed role ARN is composed from the account id
+// and the configured role name.
+func TestGetConfigRoleARN(t *testing.T) {
+	ctx := context.Background()
+	rec := &sessionNameRecorder{expiresIn: time.Hour}
+	f := newTestFactory(rec)
+
+	_, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+	require.Equal(t, "arn:aws:iam::123456789012:role/BatonRole", rec.roleARN)
+}
+
+type sessionNameRecorder struct {
+	expiresIn   time.Duration
+	sessionName string
+	roleARN     string
+}
+
+func (r *sessionNameRecorder) AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	r.sessionName = awsSdk.ToString(in.RoleSessionName)
+	r.roleARN = awsSdk.ToString(in.RoleArn)
+	return &sts.AssumeRoleOutput{Credentials: fakeCredentials(r.expiresIn)}, nil
+}
+
+// TestIsAccessDeniedErrorSSOAdmin covers the second half of CXP-801: SSO Admin returns a
+// typed AccessDeniedException whose code is "AccessDeniedException", which the old
+// "AccessDenied"-only comparison missed, leaving the fail-soft skips in permission_set.go
+// and inline_policy.go dead.
+func TestIsAccessDeniedErrorSSOAdmin(t *testing.T) {
+	t.Run("iam unmodeled AccessDenied", func(t *testing.T) {
+		require.True(t, isAccessDeniedError(iamAccessDenied()))
+	})
+
+	t.Run("sso admin typed AccessDeniedException", func(t *testing.T) {
+		err := &awsSsoAdminTypes.AccessDeniedException{Message: awsSdk.String("nope")}
+		require.True(t, isAccessDeniedError(wrapAsOperationError("SSO Admin", "ListManagedPoliciesInPermissionSet", err)))
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		require.False(t, isAccessDeniedError(errors.New("boom")))
+	})
+
+	t.Run("different api error code", func(t *testing.T) {
+		err := &smithy.GenericAPIError{Code: "ValidationException", Message: "bad input"}
+		require.False(t, isAccessDeniedError(wrapAsOperationError("IAM", "ListGroups", err)))
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		require.False(t, isAccessDeniedError(nil))
+	})
+}
+
+// TestCredentialsFailureIsNotTreatedAsResourceDenial is the guard against the regression
+// the refreshing-credentials fix would otherwise introduce. Once credentials re-assume
+// lazily, an STS AccessDenied surfaces at the IAM call site through the credentials
+// chain. If isAccessDeniedError matched it, every fail-soft skip would swallow a
+// credentials outage and the sync would report success with grants silently missing —
+// which reads downstream as revoked access.
+func TestCredentialsFailureIsNotTreatedAsResourceDenial(t *testing.T) {
+	// Mirrors the real wrap chain:
+	//   IAM OperationError → "get identity: %w" → "get credentials: %w" → STS OperationError
+	stsErr := wrapAsOperationError(sts.ServiceID, "AssumeRole", &smithy.GenericAPIError{
+		Code:    errCodeAccessDenied,
+		Message: "User is not authorized to perform: sts:AssumeRole",
+	})
+	credsErr := fmt.Errorf("get identity: %w", fmt.Errorf("get credentials: %w", stsErr))
+	iamErr := wrapAsOperationError(awsIam.ServiceID, "ListAttachedUserPolicies", credsErr)
+
+	require.True(t, isCredentialsRetrievalError(iamErr),
+		"an STS error nested under an IAM operation must be recognized as a credentials failure")
+	require.False(t, isAccessDeniedError(iamErr),
+		"a credentials failure must NOT be skippable — it has to fail the sync loudly")
+}
+
+// TestIsCredentialsRetrievalErrorIgnoresResourceDenials ensures a genuine IAM denial is
+// still skippable, i.e. the new guard is not over-broad.
+func TestIsCredentialsRetrievalErrorIgnoresResourceDenials(t *testing.T) {
+	err := iamAccessDenied()
+	require.False(t, isCredentialsRetrievalError(err))
+	require.True(t, isAccessDeniedError(err))
+}
+
+// TestIsCredentialsRetrievalErrorDirectSTSCall documents that a denial raised by a direct
+// STS call (not through the credentials chain) is also classified as a credentials
+// failure. baton-aws only calls STS to obtain credentials, so this is the correct read.
+func TestIsCredentialsRetrievalErrorDirectSTSCall(t *testing.T) {
+	err := stsAccessDenied()
+	require.True(t, isCredentialsRetrievalError(err))
+	require.False(t, isAccessDeniedError(err))
+}
+
+func iamAccessDenied() error {
+	return wrapAsOperationError(awsIam.ServiceID, "ListAttachedUserPolicies", &smithy.GenericAPIError{
+		Code:    errCodeAccessDenied,
+		Message: "not authorized",
+	})
+}
+
+func stsAccessDenied() error {
+	return wrapAsOperationError(sts.ServiceID, "AssumeRole", &smithy.GenericAPIError{
+		Code:    errCodeAccessDenied,
+		Message: "not authorized to assume role",
+	})
+}
+
+func wrapAsOperationError(serviceID, op string, err error) error {
+	return &smithy.OperationError{ServiceID: serviceID, OperationName: op, Err: err}
+}

--- a/pkg/connector/aws_client_factory_test.go
+++ b/pkg/connector/aws_client_factory_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -58,7 +59,27 @@ func fakeCredentials(expiresIn time.Duration) *stsTypes.Credentials {
 	}
 }
 
-func newTestFactory(stsClient stscreds.AssumeRoleAPIClient) *AWSClientFactory {
+// isolateAWSEnv detaches the process's ambient AWS configuration for the duration of a
+// test. getConfig goes through awsConfig.LoadDefaultConfig, which reads the environment
+// and the shared config files, so without this a developer machine with AWS_PROFILE set
+// fails these tests with "failed to get shared config profile" instead of exercising the
+// code under test. Only profile/credential-file resolution is neutralized — tests that
+// assert on ambient settings set their own AWS_* vars on top of this.
+func isolateAWSEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
+	t.Setenv("AWS_CONFIG_FILE", os.DevNull)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", os.DevNull)
+	// Credentials are always supplied explicitly here, so a stray IMDS probe would only
+	// add latency and a dependency on the host.
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+}
+
+func newTestFactory(t *testing.T, stsClient stscreds.AssumeRoleAPIClient) *AWSClientFactory {
+	t.Helper()
+	isolateAWSEnv(t)
+
 	return &AWSClientFactory{
 		mutex:        sync.Mutex{},
 		config:       Config{GlobalRegion: "us-east-1", IamAssumeRoleName: "BatonRole"},
@@ -78,7 +99,7 @@ func TestGetConfigCredentialsRefreshOnExpiry(t *testing.T) {
 	ctx := context.Background()
 	// Already expired on arrival, so the second Retrieve must trigger a fresh AssumeRole.
 	fake := &fakeSTSClient{expiresIn: -time.Minute}
-	f := newTestFactory(fake)
+	f := newTestFactory(t, fake)
 
 	cfg, err := f.getConfig(ctx, "123456789012")
 	require.NoError(t, err)
@@ -94,7 +115,7 @@ func TestGetConfigCredentialsRefreshOnExpiry(t *testing.T) {
 func TestGetConfigCredentialsCachedWhileValid(t *testing.T) {
 	ctx := context.Background()
 	fake := &fakeSTSClient{expiresIn: time.Hour}
-	f := newTestFactory(fake)
+	f := newTestFactory(t, fake)
 
 	cfg, err := f.getConfig(ctx, "123456789012")
 	require.NoError(t, err)
@@ -104,6 +125,26 @@ func TestGetConfigCredentialsCachedWhileValid(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Equal(t, 1, fake.callCount(), "valid credentials should be served from cache")
+}
+
+// TestGetConfigRefreshesBeforeExpiry pins the refresh window. Credentials whose remaining
+// life falls inside crossAccountCredentialRefreshWindow must be re-assumed rather than
+// served, because a request signed with them can reach AWS after they expire and come back
+// 403 ExpiredToken — which is absent from the SDK's retryable error codes.
+func TestGetConfigRefreshesBeforeExpiry(t *testing.T) {
+	ctx := context.Background()
+	// Still valid, but well inside the refresh window.
+	fake := &fakeSTSClient{expiresIn: crossAccountCredentialRefreshWindow / 2}
+	f := newTestFactory(t, fake)
+
+	cfg, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+
+	before := fake.callCount()
+	_, err = cfg.Credentials.Retrieve(ctx)
+	require.NoError(t, err)
+	require.Greater(t, fake.callCount(), before,
+		"credentials expiring inside the refresh window must be re-assumed, not signed with")
 }
 
 // TestGetConfigProbesAssumability covers what accountIAMResourceType.parseAssumeRole
@@ -117,7 +158,7 @@ func TestGetConfigProbesAssumability(t *testing.T) {
 		errAfter:  1,
 		err:       stsAccessDenied(),
 	}
-	f := newTestFactory(fake)
+	f := newTestFactory(t, fake)
 
 	_, err := f.getConfig(ctx, "123456789012")
 	require.Error(t, err, "getConfig must report a role it cannot assume")
@@ -128,7 +169,7 @@ func TestGetConfigProbesAssumability(t *testing.T) {
 func TestGetConfigUsesStableSessionName(t *testing.T) {
 	ctx := context.Background()
 	rec := &sessionNameRecorder{expiresIn: time.Hour}
-	f := newTestFactory(rec)
+	f := newTestFactory(t, rec)
 
 	_, err := f.getConfig(ctx, "123456789012")
 	require.NoError(t, err)
@@ -147,7 +188,7 @@ func TestGetConfigResolvesAmbientAWSSettings(t *testing.T) {
 	t.Setenv("AWS_SDK_UA_APP_ID", "baton-aws-probe")
 
 	ctx := context.Background()
-	f := newTestFactory(&fakeSTSClient{expiresIn: time.Hour})
+	f := newTestFactory(t, &fakeSTSClient{expiresIn: time.Hour})
 
 	cfg, err := f.getConfig(ctx, "123456789012")
 	require.NoError(t, err)
@@ -169,7 +210,7 @@ func TestGetConfigResolvesAmbientAWSSettings(t *testing.T) {
 func TestGetConfigPreservesRefreshingCredentialsThroughLoadDefaultConfig(t *testing.T) {
 	ctx := context.Background()
 	fake := &fakeSTSClient{expiresIn: -time.Minute}
-	f := newTestFactory(fake)
+	f := newTestFactory(t, fake)
 
 	cfg, err := f.getConfig(ctx, "123456789012")
 	require.NoError(t, err)
@@ -188,22 +229,42 @@ func TestGetConfigPreservesRefreshingCredentialsThroughLoadDefaultConfig(t *test
 func TestGetConfigRoleARN(t *testing.T) {
 	ctx := context.Background()
 	rec := &sessionNameRecorder{expiresIn: time.Hour}
-	f := newTestFactory(rec)
+	f := newTestFactory(t, rec)
 
 	_, err := f.getConfig(ctx, "123456789012")
 	require.NoError(t, err)
 	require.Equal(t, "arn:aws:iam::123456789012:role/BatonRole", rec.roleARN)
 }
 
+// TestGetConfigRequestsOneHourSessions pins the session length actually sent to STS.
+// stscreds does not inherit the STS API's 1-hour default: AssumeRoleProvider.Retrieve
+// back-fills an unset Duration with stscreds.DefaultDuration (15 minutes) and always sends
+// DurationSeconds. Dropping aro.Duration would therefore quarter the session length and
+// quadruple AssumeRole volume across every child account, silently and with no test
+// failure — hence this assertion on the wire value rather than on the constant.
+func TestGetConfigRequestsOneHourSessions(t *testing.T) {
+	ctx := context.Background()
+	rec := &sessionNameRecorder{expiresIn: time.Hour}
+	f := newTestFactory(t, rec)
+
+	_, err := f.getConfig(ctx, "123456789012")
+	require.NoError(t, err)
+	require.Equal(t, int32(3600), awsSdk.ToInt32(rec.durationSeconds),
+		"cross-account sessions must request 3600s: the maximum role chaining permits, "+
+			"and what the pre-refresh code received from the STS API default")
+}
+
 type sessionNameRecorder struct {
-	expiresIn   time.Duration
-	sessionName string
-	roleARN     string
+	expiresIn       time.Duration
+	sessionName     string
+	roleARN         string
+	durationSeconds *int32
 }
 
 func (r *sessionNameRecorder) AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
 	r.sessionName = awsSdk.ToString(in.RoleSessionName)
 	r.roleARN = awsSdk.ToString(in.RoleArn)
+	r.durationSeconds = in.DurationSeconds
 	return &sts.AssumeRoleOutput{Credentials: fakeCredentials(r.expiresIn)}, nil
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -611,18 +611,23 @@ func GetAwsConfigOptions(httpClient *http.Client, config Config) []func(*awsConf
 	return opts
 }
 
-func GetAwsConfigOptionsForAssumeRole(output *sts.AssumeRoleOutput, httpClient *http.Client, config Config) []func(*awsConfig.LoadOptions) error {
+// GetAwsConfigOptionsForCredentials builds load options for a config backed by an
+// explicit credentials provider.
+//
+// These are passed to awsConfig.LoadDefaultConfig rather than used to hand-build an
+// awsSdk.Config so that cross-account clients keep resolving ambient AWS settings —
+// AWS_RETRY_MODE, AWS_MAX_ATTEMPTS, AWS_SDK_UA_APP_ID, request-compression settings,
+// AccountIDEndpointMode, and (via ConfigSources) FIPS / dualstack / endpoint resolution.
+// Only credentials, region, HTTP client, and defaults mode are pinned here.
+//
+// The provider is expected to be an *awsSdk.CredentialsCache; LoadDefaultConfig passes
+// one through untouched instead of re-wrapping it, preserving its refresh behavior.
+func GetAwsConfigOptionsForCredentials(creds awsSdk.CredentialsProvider, httpClient *http.Client, config Config) []func(*awsConfig.LoadOptions) error {
 	opts := []func(*awsConfig.LoadOptions) error{
 		awsConfig.WithHTTPClient(httpClient),
 		awsConfig.WithRegion(config.GlobalRegion),
 		awsConfig.WithDefaultsMode(awsSdk.DefaultsModeInRegion),
-		awsConfig.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(
-				*output.Credentials.AccessKeyId,
-				*output.Credentials.SecretAccessKey,
-				*output.Credentials.SessionToken,
-			),
-		),
+		awsConfig.WithCredentialsProvider(creds),
 	}
 
 	return opts

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	aws_middleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	awsIdentityStoreTypes "github.com/aws/aws-sdk-go-v2/service/identitystore/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithy "github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -21,6 +22,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// errCodeAccessDenied is the unmodeled code IAM (and STS) return for an authorization
+	// failure; errCodeAccessDeniedException is the code carried by service-modeled
+	// AccessDeniedException types, e.g. SSO Admin's.
+	errCodeAccessDenied          = "AccessDenied"
+	errCodeAccessDeniedException = "AccessDeniedException"
 )
 
 const (
@@ -428,13 +437,62 @@ func wrapAWSError(err error) error {
 	return err
 }
 
+// isCredentialsRetrievalError reports whether err originated in an STS credential
+// retrieval rather than in the API call the caller actually made.
+//
+// Cross-account clients hold auto-refreshing assumed-role credentials, so when a
+// re-assume fails mid-sync (role deleted, trust policy edited, SCP change) STS returns
+// AccessDenied and the SDK surfaces it at the call site — the whole chain is %w-wrapped
+// and reachable by errors.As:
+//
+//	iam.<Op> err → smithy.OperationError{ServiceID:"IAM"} → "get identity: %w"
+//	  → "get credentials: %w" → CredentialsCache → AssumeRoleProvider
+//	  → smithy.OperationError{ServiceID:"STS"} → GenericAPIError{Code:"AccessDenied"}
+//
+// Without this check isAccessDeniedError matches that error and the fail-soft skips
+// treat a credentials outage as "this resource denied us", producing a sync that reports
+// success with grants silently missing. Absent grants read as revoked access downstream,
+// so a partial sync is worse than a hard failure: credential problems must be loud.
+//
+// A plain errors.As is not enough: it matches the OUTERMOST *smithy.OperationError, which
+// is the caller's own service (IAM), and would never see the STS one nested beneath it.
+// So each match that is not STS is stepped past, and the search resumes underneath it.
+func isCredentialsRetrievalError(err error) bool {
+	for e := err; e != nil; {
+		var opErr *smithy.OperationError
+		if !errors.As(e, &opErr) {
+			return false
+		}
+		if opErr.ServiceID == sts.ServiceID {
+			return true
+		}
+		e = errors.Unwrap(opErr)
+	}
+	return false
+}
+
+// isAccessDeniedError reports whether err is a resource-level authorization denial that
+// the caller may safely skip.
+//
+// Both spellings are matched: IAM models no AccessDenied* error type and returns an
+// unmodeled GenericAPIError with code "AccessDenied", while SSO Admin returns a typed
+// *ssoadmin.AccessDeniedException whose ErrorCode() is "AccessDeniedException". Matching
+// only the former left the fail-soft skips in permission_set.go and inline_policy.go dead
+// for SSO Admin, failing the sync instead of degrading.
+//
+// Credential-retrieval failures are explicitly excluded — see isCredentialsRetrievalError.
 func isAccessDeniedError(err error) bool {
+	if isCredentialsRetrievalError(err) {
+		return false
+	}
+
 	var apiErr smithy.APIError
 	if !errors.As(err, &apiErr) {
 		return false
 	}
+
 	switch apiErr.ErrorCode() {
-	case "AccessDenied", "AccessDeniedException":
+	case errCodeAccessDenied, errCodeAccessDeniedException:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Fixes [CXP-801](https://linear.app/ductone/issue/CXP-801/baton-aws-cross-account-clients-cache-expired-sts-credentials-every). Go-live blocker for The Trade Desk ([Pylon #12224](https://app.usepylon.com/issues?issueNumber=12224)).

## Problem

`AWSClientFactory` built per-child-account IAM clients from a single `sts:AssumeRole` call, wrapped the result in `credentials.NewStaticCredentialsProvider` (never refreshes), and cached the client in `iamClientMap` for the lifetime of the process — no TTL, no expiry check, no invalidation.

Assumed-role sessions last at most 1 hour: role chaining caps there, and an `AssumeRole` call with no `DurationSeconds` defaults there anyway, so the 1-hour ceiling applied in every deployment mode. Clients are created eagerly at account-listing time (`account_iam.go`) but used later during the child IAM crawl, so:

- any sync where >1h elapsed between creation and use died mid-sync with `403 ExpiredToken`, and
- the cached client then failed **every subsequent sync** until the process restarted.

## Fix

`getConfig` now builds `aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(...))`, matching the pattern already used for the connector's own credentials in `(*AWS).getCallingConfig`. Caching the client is safe once its provider re-assumes on expiry.

Three details that aren't obvious from the diff:

**The eager `Retrieve` is load-bearing, not a sanity check.** `stscreds` providers are lazy — constructing one issues no API call. `accountIAMResourceType.parseAssumeRole` relies on an assume-role failure to skip inaccessible accounts, so without the probe those accounts would be silently registered and fail later mid-crawl. This isn't hypothetical: the verification run below hit an account that exercises it.

**`LoadDefaultConfig` is retained deliberately.** I initially hand-built an `aws.Config` and measured what that drops: `RetryMode`, `RetryMaxAttempts`, `AppID`, `RequestMinCompressSizeBytes`, `DisableRequestCompression`, `AccountIDEndpointMode`, and `ConfigSources`. That last one is where service clients read FIPS/dualstack and endpoint settings at construction, so an empty one would silently disable `AWS_USE_FIPS_ENDPOINT` for cross-account clients only. `GetAwsConfigOptionsForAssumeRole` is replaced by `GetAwsConfigOptionsForCredentials`, which takes a `CredentialsProvider` instead of an `*sts.AssumeRoleOutput`. `config.wrapWithCredentialsCache` returns an existing `*aws.CredentialsCache` untouched rather than re-wrapping, so refresh behavior survives the round trip — pinned by a test.

**Refreshing credentials introduce a new silent-data-loss path, closed here.** Once credentials re-assume lazily, an STS `AccessDenied` on re-assume surfaces at the IAM call site through the `%w`-wrapped chain:

```
iam.<Op> err → smithy.OperationError{ServiceID:"IAM"} → "get identity: %w"
  → "get credentials: %w" → CredentialsCache → AssumeRoleProvider
  → smithy.OperationError{ServiceID:"STS"} → GenericAPIError{Code:"AccessDenied"}
```

`errors.As` traverses all of it, so the existing fail-soft guards would have mistaken a credentials outage for a resource-level denial and skipped — a sync reporting success with grants silently missing, which reads downstream as revoked access. Strictly worse than the loud `ExpiredToken` we're fixing. `isCredentialsRetrievalError` excludes those. Note it can't use a plain `errors.As`: that matches the *outermost* `OperationError` (IAM) and never sees the STS one beneath, so it steps past each non-STS match and resumes underneath.

## Secondary fix (same error family, per the ticket)

`isAccessDeniedError` only matched `"AccessDenied"`. IAM models no `AccessDenied*` error type and returns an unmodeled `GenericAPIError` with that code, but SSO Admin returns a typed `AccessDeniedException` whose `ErrorCode()` is `"AccessDeniedException"` — so the fail-soft skips at `permission_set.go:136` and `inline_policy.go:162` were dead code and failed the sync instead of degrading. Both spellings now match. (`sts_actions.go:188` already had this shape.)

## Verification

Live tenant, 2-account org, `--global-aws-cross-account-iam-enabled`.

**Credential refresh** — with a temporary always-expired `ExpiryWindow` plus per-call `AssumeRole` logging, one child account logged **42 successive `AssumeRole` calls** (numbered 1→42) through the single cached IAM client. On the old code that number is exactly 1, forever.

**Eager probe** — account `852922979753` returned `403 AccessDenied` on `AssumeRole`; the probe caught it and the account was skipped via `Skipping account in Organizations`, preserving pre-fix semantics.

**A/B on the `AccessDenied` half** — reverting only the code-matching and re-running the same sync:

| | result |
|---|---|
| pre-fix matching | `exit=1` — `cancelling context due to error in action` on `ssoadmin.GetInlinePolicyForPermissionSet` |
| this PR | `exit=0` — 8 fail-soft skips logged as warnings, `Sync complete.` |

The tenant's `test-user` lacks `sso:ListManagedPoliciesInPermissionSet` and `sso:GetInlinePolicyForPermissionSet`, so it reproduces the dead-guard bug directly.

**Final clean run** on the exact committed code (no instrumentation): `exit=0`, `Sync complete.`, zero `ExpiredToken`.

`go build`, `go vet`, full `go test`, and `-race` all pass. `golangci-lint`: 12 issues vs. 14 on `main` — zero new, two pre-existing `goconst` findings cleared.

## Tests

11 tests in `pkg/connector/aws_client_factory_test.go`, using an injectable `stsClientFn` seam. Each guard was **mutation-tested** to confirm it actually bites:

- drop the credentials guard → `TestCredentialsFailureIsNotTreatedAsResourceDenial` fails
- revert to `AccessDenied`-only → the SSO Admin subtest fails
- hand-build the `aws.Config` → `TestGetConfigResolvesAmbientAWSSettings` fails on `AWS_RETRY_MODE`

## Acceptance criteria

- [x] Cross-account IAM clients use auto-refreshing assumed-role credentials
- [x] A sync against child accounts completes without `ExpiredToken` — refresh demonstrated via the 42-call sequence rather than a >1h wait
- [~] Subsequent syncs in a long-lived process succeed without restart — not directly observable via `go run` (one sync per process); same `CredentialsCache` mechanism as above
- [x] `isAccessDeniedError` matches SSO Admin `AccessDeniedException`; skip paths covered by unit tests

## Reviewer notes

- `GetAwsConfigOptionsForCredentials` **replaces an exported symbol** (`GetAwsConfigOptionsForAssumeRole`). Only caller was `aws_client_factory.go`, but worth confirming nothing outside this repo referenced it.
- `isCredentialsRetrievalError` is covered by unit tests only. Hitting it live needs a role that assumes successfully at probe time and then loses permission mid-sync — hard to stage deliberately.
- Deliberately **out of scope**, all pre-existing: no negative caching for unassumable accounts (13 call sites re-attempt `AssumeRole` per denied account); `f.mutex` is a single global lock held across the STS call; `orgClientMap` is declared and never read — note the ticket's criterion 1 says "IAM/**org** clients" but no cross-account org path exists. Plus the ticket's own README least-privilege follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)