### PR TITLE
docs: add missing SSO permission-set policy actions to IAM setup

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -397,8 +397,10 @@ The permissions policy below is broken into several sections to align with these
 	        "identitystore:ListUsers",
 	        "organizations:ListAccounts",
 	        "sso:DescribePermissionSet",
+	        "sso:GetInlinePolicyForPermissionSet",
 	        "sso:ListAccountAssignments",
 	        "sso:ListInstances",
+	        "sso:ListManagedPoliciesInPermissionSet",
 	        "sso:ListPermissionSets",
 	        "sso:ListPermissionSetsProvisionedToAccount",
 	        "organizations:ListRoots",
@@ -498,7 +500,7 @@ The permissions policy below is broken into several sections to align with these
 	- `iam:List..., iam:GetGroup`: These are standard IAM permissions for listing users, groups, and roles. They are necessary to identify resources within your AWS account. iam:GetGroup provides the members of a group.
 	- `identitystore:List...`: These permissions are specific to AWS IAM Identity Center. They allow C1 to list and read information about your users and groups as they are defined within the Identity Center.
 	- `organizations:ListAccounts`: This permission is required to list all the accounts within your AWS Organization, enabling C1 to understand your account structure.
-	- `sso:List..., sso:Describe...`: These permissions allow C1 to list your permission sets and see how they are assigned to accounts and users.
+	- `sso:List..., sso:Describe..., sso:Get...`: These permissions allow C1 to list your permission sets, see how they are assigned to accounts and users, and read the inline and managed IAM policies attached to each permission set.
 	- `organizations:ListRoots, organizations:ListOrganizationalUnitsForParent`: **Optional**, only needed for the Sparse ACLs Organization Root / Organizational Unit hierarchy (see [Sparse ACLs](#sparse-acls-organizations-and-permission-sets-as-scoped-bindings) above). If omitted, the connector logs a warning and skips the OU hierarchy instead of failing.
 	- `iam:GetUser, and various iam:List... permissions`: These permissions are necessary for C1 to first retrieve all associated credentials and metadata for an IAM user before a complete deletion can be performed.
 	**Section 2: Provisioning access (“C1ProvisionAccess”)**
@@ -777,8 +779,10 @@ resource "aws_iam_role" "ConductorOneIntegration" {
             "identitystore:ListUsers",
             "organizations:ListAccounts",
             "sso:DescribePermissionSet",
+            "sso:GetInlinePolicyForPermissionSet",
             "sso:ListAccountAssignments",
             "sso:ListInstances",
+            "sso:ListManagedPoliciesInPermissionSet",
             "sso:ListPermissionSets",
             "sso:ListPermissionSetsProvisionedToAccount"
           ],


### PR DESCRIPTION
## Summary

- Adds `sso:GetInlinePolicyForPermissionSet` and `sso:ListManagedPoliciesInPermissionSet` to the documented IAM policy (JSON and Terraform blocks), and updates the accompanying permissions notes to cover them.

These two actions were added to the connector to support permission set → IAM policy relationship syncing, but `docs/connector.mdx` was never updated to match. Users who build their IAM role from the docs and enable Identity Center (`--global-aws-sso-enabled`) hit `AccessDenied` on `sso:GetInlinePolicyForPermissionSet`, which aborts the entire sync.

This mirrors a fix already applied on the docs side in ConductorOne/docs#398 — opening this so the next docs sync doesn't overwrite that fix with the stale policy.

## Test plan

- [ ] Confirm the JSON and Terraform policy blocks render correctly
- [ ] Confirm the updated permissions note reads correctly alongside the existing Section 1 notes