### PR TITLE
Update required permissions in README and capabilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,30 @@ _These policies have comments prefixed with // that need to be removed before us
     {
       "Action": [
         "iam:ListUsers",
+        "iam:GetUser",
         "iam:ListGroups",
-        "iam:ListRoles",
         "iam:GetGroup",
+        "iam:ListAttachedGroupPolicies",
+        "iam:ListRoles",
         "iam:GetRole",
+        "iam:ListAttachedRolePolicies",
         "iam:ListAccessKeys",
         "iam:GetAccessKeyLastUsed",
+        "iam:ListSigningCertificates",
+        "iam:ListSSHPublicKeys",
+        "iam:ListServiceSpecificCredentials",
+        "iam:ListMFADevices",
+        "iam:ListUserPolicies",
+        "iam:ListAttachedUserPolicies",
+        "iam:ListGroupsForUser",
+        "iam:ListRolePolicies",
+        "iam:ListGroupPolicies",
+        "iam:GetUserPolicy",
+        "iam:GetRolePolicy",
+        "iam:GetGroupPolicy",
+        "iam:ListPolicies",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion"
       ],
       "Effect": "Allow",
       "Resource": "*",
@@ -161,16 +179,23 @@ _These policies have comments prefixed with // that need to be removed before us
     },
     {
       "Action": [
-        "identitystore:GetGroupMembershipId",
         "identitystore:ListUsers",
         "identitystore:ListGroups",
         "identitystore:ListGroupMemberships",
+        "identitystore:GetGroupMembershipId",
         "organizations:ListAccounts",
-        "sso:DescribePermissionSet",
-        "sso:ListAccountAssignments",
+        "organizations:DescribeOrganization",
+        "organizations:ListParents",
+        "organizations:ListRoots",
+        "organizations:ListOrganizationalUnitsForParent",
         "sso:ListInstances",
         "sso:ListPermissionSets",
-        "sso:ListPermissionSetsProvisionedToAccount"
+        "sso:DescribePermissionSet",
+        "sso:ListManagedPoliciesInPermissionSet",
+        "sso:ListCustomerManagedPolicyReferencesInPermissionSet",
+        "sso:GetInlinePolicyForPermissionSet",
+        "sso:ListPermissionSetsProvisionedToAccount",
+        "sso:ListAccountAssignments"
       ],
       "Effect": "Allow",
       "Resource": "*",
@@ -210,12 +235,30 @@ _These policies have comments prefixed with // that need to be removed before us
     {
       "Action": [
         "iam:ListUsers",
+        "iam:GetUser",
         "iam:ListGroups",
-        "iam:ListRoles",
         "iam:GetGroup",
+        "iam:ListAttachedGroupPolicies",
+        "iam:ListRoles",
         "iam:GetRole",
+        "iam:ListAttachedRolePolicies",
         "iam:ListAccessKeys",
-        "iam:GetAccessKeyLastUsed"
+        "iam:GetAccessKeyLastUsed",
+        "iam:ListSigningCertificates",
+        "iam:ListSSHPublicKeys",
+        "iam:ListServiceSpecificCredentials",
+        "iam:ListMFADevices",
+        "iam:ListUserPolicies",
+        "iam:ListAttachedUserPolicies",
+        "iam:ListGroupsForUser",
+        "iam:ListRolePolicies",
+        "iam:ListGroupPolicies",
+        "iam:GetUserPolicy",
+        "iam:GetRolePolicy",
+        "iam:GetGroupPolicy",
+        "iam:ListPolicies",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion"
       ],
       "Effect": "Allow",
       "Resource": "*",
@@ -233,16 +276,23 @@ _These policies have comments prefixed with // that need to be removed before us
     },
     {
       "Action": [
-        "identitystore:GetGroupMembershipId",
         "identitystore:ListUsers",
         "identitystore:ListGroups",
         "identitystore:ListGroupMemberships",
+        "identitystore:GetGroupMembershipId",
         "organizations:ListAccounts",
-        "sso:DescribePermissionSet",
-        "sso:ListAccountAssignments",
+        "organizations:DescribeOrganization",
+        "organizations:ListParents",
+        "organizations:ListRoots",
+        "organizations:ListOrganizationalUnitsForParent",
         "sso:ListInstances",
         "sso:ListPermissionSets",
-        "sso:ListPermissionSetsProvisionedToAccount"
+        "sso:DescribePermissionSet",
+        "sso:ListManagedPoliciesInPermissionSet",
+        "sso:ListCustomerManagedPolicyReferencesInPermissionSet",
+        "sso:GetInlinePolicyForPermissionSet",
+        "sso:ListPermissionSetsProvisionedToAccount",
+        "sso:ListAccountAssignments"
       ],
       "Effect": "Allow",
       "Resource": "*",
@@ -258,6 +308,40 @@ _These policies have comments prefixed with // that need to be removed before us
       "Resource": "*",
       // Enable provisioning of IAM users to Groups
       "Sid": "IAMUserToGroupProvisioning"
+    },
+    {
+      "Action": [
+        "iam:AttachUserPolicy",
+        "iam:AttachRolePolicy",
+        "iam:AttachGroupPolicy",
+        "iam:DetachUserPolicy",
+        "iam:DetachRolePolicy",
+        "iam:DetachGroupPolicy",
+        "iam:DeleteUserPolicy",
+        "iam:DeleteRolePolicy",
+        "iam:DeleteGroupPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      // Attach/detach managed policies and revoke IAM inline policies
+      "Sid": "IAMPolicyProvisioning"
+    },
+    {
+      "Action": [
+        "iam:CreateUser",
+        "iam:TagUser",
+        "iam:DeleteLoginProfile",
+        "iam:DeleteAccessKey",
+        "iam:DeleteSigningCertificate",
+        "iam:DeleteSSHPublicKey",
+        "iam:DeleteServiceSpecificCredential",
+        "iam:DeactivateMFADevice",
+        "iam:DeleteUser"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      // Create and delete IAM users (delete requires clearing credentials first)
+      "Sid": "IAMUserAccountProvisioning"
     },
     {
       "Action": [
@@ -382,17 +466,36 @@ Each sub-account will need to have the following policy attached to the role tha
     {
       "Action": [
         "iam:ListUsers",
+        "iam:GetUser",
         "iam:ListGroups",
-        "iam:ListRoles",
         "iam:GetGroup",
+        "iam:ListAttachedGroupPolicies",
+        "iam:ListRoles",
         "iam:GetRole",
+        "iam:ListAttachedRolePolicies",
         "iam:ListAccessKeys",
         "iam:GetAccessKeyLastUsed",
+        "iam:ListSigningCertificates",
+        "iam:ListSSHPublicKeys",
+        "iam:ListServiceSpecificCredentials",
+        "iam:ListMFADevices",
+        "iam:ListUserPolicies",
+        "iam:ListAttachedUserPolicies",
+        "iam:ListGroupsForUser",
+        "iam:ListRolePolicies",
+        "iam:ListGroupPolicies",
+        "iam:GetUserPolicy",
+        "iam:GetRolePolicy",
+        "iam:GetGroupPolicy",
+        "iam:ListPolicies",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:ListAccountAliases"
       ],
       "Effect": "Allow",
       "Resource": "*",
       "Sid": "MinimumRequiredPermissionsSyncIAMUsersGroupsRoles"
-    },
+    }
   ],
   "Version": "2012-10-17"
 }

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -810,6 +810,12 @@
                 "permission": "sso:ListAccountAssignments"
               },
               {
+                "permission": "sso:ListManagedPoliciesInPermissionSet"
+              },
+              {
+                "permission": "sso:ListCustomerManagedPolicyReferencesInPermissionSet"
+              },
+              {
                 "permission": "sso:CreateAccountAssignment"
               },
               {
@@ -845,6 +851,12 @@
           },
           {
             "permission": "sso:ListAccountAssignments"
+          },
+          {
+            "permission": "sso:ListManagedPoliciesInPermissionSet"
+          },
+          {
+            "permission": "sso:ListCustomerManagedPolicyReferencesInPermissionSet"
           },
           {
             "permission": "sso:CreateAccountAssignment"

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -430,7 +430,15 @@ func wrapAWSError(err error) error {
 
 func isAccessDeniedError(err error) bool {
 	var apiErr smithy.APIError
-	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDenied"
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "AccessDenied", "AccessDeniedException":
+		return true
+	default:
+		return false
+	}
 }
 
 type ssoUserCreateProfile struct {

--- a/pkg/connector/iam_policy.go
+++ b/pkg/connector/iam_policy.go
@@ -212,9 +212,12 @@ func (o *iamPolicyResourceType) Entitlements(_ context.Context, resource *v2.Res
 			resourceTypeIAMUser,
 			resourceTypeRole,
 			resourceTypeIAMGroup,
-			// Structural principal: Identity Center permission sets hold their managed
-			// policies through this entitlement (see permissionSetResourceType.Grants).
+			// Structural principals: permission sets hold their managed policies through
+			// this entitlement (permissionSetResourceType.Grants), and permission-set
+			// bindings hold expandable per-account copies
+			// (permissionSetAssignmentResourceType.policyCompositionGrants).
 			resourceTypePermissionSet,
+			resourceTypePermissionSetAssignment,
 		),
 	)
 	attached.Description = fmt.Sprintf("Has the %s managed policy in AWS", resource.DisplayName)

--- a/pkg/connector/permission_set_assignment.go
+++ b/pkg/connector/permission_set_assignment.go
@@ -2,14 +2,21 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsSsoAdmin "github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	entitlementSdk "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	grantSdk "github.com/conductorone/baton-sdk/pkg/types/grant"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 // permissionSetAssignmentEntitlement is the binding's assignment entitlement slug. It MUST
@@ -149,6 +156,15 @@ func (o *permissionSetAssignmentResourceType) Entitlements(_ context.Context, re
 	return []*v2.Entitlement{assignedEntitlement(resource)}, nil, nil
 }
 
+// bindingGrantsPageState sequences the binding's two-phase Grants crawl:
+// account-assignment grants first (AWSToken carries ListAccountAssignments'
+// NextToken across pages), then one final page of policy-composition grants
+// (per-permission-set policy counts are small, bounded by AWS quotas).
+type bindingGrantsPageState struct {
+	PoliciesPhase bool   `json:"pp,omitempty"`
+	AWSToken      string `json:"t,omitempty"`
+}
+
 func (o *permissionSetAssignmentResourceType) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
 	scope, err := resourceSdk.GetScopeBindingTrait(resource)
 	if err != nil {
@@ -157,6 +173,19 @@ func (o *permissionSetAssignmentResourceType) Grants(ctx context.Context, resour
 	accountID := scope.GetScopeResourceId().GetResource()
 	permissionSetArn := scope.GetRoleId().GetResource()
 
+	pageState, err := decodePageToken[bindingGrantsPageState](opts.PageToken.Token)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-aws: failed to decode page token: %w", err)
+	}
+
+	if pageState.PoliciesPhase {
+		grants, err := o.policyCompositionGrants(ctx, opts.Session, resource, permissionSetArn, accountID)
+		if err != nil {
+			return nil, nil, err
+		}
+		return grants, nil, nil
+	}
+
 	entitlement := assignedEntitlement(resource)
 
 	input := &awsSsoAdmin.ListAccountAssignmentsInput{
@@ -164,8 +193,8 @@ func (o *permissionSetAssignmentResourceType) Grants(ctx context.Context, resour
 		InstanceArn:      o.account.identityInstance.InstanceArn,
 		PermissionSetArn: awsSdk.String(permissionSetArn),
 	}
-	if opts.PageToken.Token != "" {
-		input.NextToken = awsSdk.String(opts.PageToken.Token)
+	if pageState.AWSToken != "" {
+		input.NextToken = awsSdk.String(pageState.AWSToken)
 	}
 
 	resp, err := o.account.ssoAdminClient.ListAccountAssignments(ctx, input)
@@ -184,10 +213,198 @@ func (o *permissionSetAssignmentResourceType) Grants(ctx context.Context, resour
 		}
 	}
 
+	// After the last assignments page, hand off to the policies phase instead of
+	// terminating, so the policy-composition grants ride the same Grants crawl.
+	nextState := bindingGrantsPageState{PoliciesPhase: true}
 	if resp.NextToken != nil && *resp.NextToken != "" {
-		return rv, &resourceSdk.SyncOpResults{NextPageToken: *resp.NextToken}, nil
+		nextState = bindingGrantsPageState{AWSToken: *resp.NextToken}
 	}
-	return rv, nil, nil
+	nextToken, err := encodePageToken(nextState)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-aws: failed to encode page token: %w", err)
+	}
+	return rv, &resourceSdk.SyncOpResults{NextPageToken: nextToken}, nil
+}
+
+// policyCompositionGrants emits the binding's policy layer: for each policy the
+// permission set carries, one grant of the policy's "attached" entitlement with
+// the BINDING as principal, annotated GrantExpandable through the binding's
+// "assigned" entitlement — so everyone assigned this permission set on this
+// account inherits the policy. (Expansion requires the expandable entitlement to
+// live on the grant's principal, which is why these grants sit on the binding;
+// the permission_set builder's structural grants — permission set as principal —
+// remain the "which policies are in this permission set" catalog view.)
+//
+// AWS-managed policies target the global policy ARN. Customer-managed policy
+// references have no ARN at the permission-set level; they resolve per account,
+// deterministically, to arn:aws:iam::<account>:policy<path><name> — which is the
+// account-local iam_policy resource this binding's account actually contains.
+func (o *permissionSetAssignmentResourceType) policyCompositionGrants(
+	ctx context.Context,
+	ss sessions.SessionStore,
+	resource *v2.Resource,
+	permissionSetArn string,
+	accountID string,
+) ([]*v2.Grant, error) {
+	expandable := &v2.GrantExpandable{
+		EntitlementIds: []string{
+			entitlementSdk.NewEntitlementID(resource, permissionSetAssignmentEntitlement),
+		},
+	}
+
+	managed, err := o.getManagedPoliciesWithCache(ctx, ss, permissionSetArn)
+	if err != nil {
+		return nil, err
+	}
+	refs, err := o.getCustomerManagedPolicyRefsWithCache(ctx, ss, permissionSetArn)
+	if err != nil {
+		return nil, err
+	}
+
+	rv := make([]*v2.Grant, 0, len(managed)+len(refs))
+	for _, policy := range managed {
+		policyARN := awsSdk.ToString(policy.Arn)
+		if policyARN == "" {
+			return nil, fmt.Errorf("baton-aws: managed policy in permission set %s missing ARN", permissionSetArn)
+		}
+		grant, err := policyAttachmentGrant(awsSdk.ToString(policy.Name), policyARN, resource.Id, expandable)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, grant)
+	}
+	for _, ref := range refs {
+		name := awsSdk.ToString(ref.Name)
+		if name == "" {
+			return nil, fmt.Errorf("baton-aws: customer managed policy reference in permission set %s missing name", permissionSetArn)
+		}
+		grant, err := policyAttachmentGrant(name, customerManagedPolicyARN(accountID, ref), resource.Id, expandable)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, grant)
+	}
+	return rv, nil
+}
+
+func policyAttachmentGrant(policyName string, policyARN string, principalID *v2.ResourceId, expandable *v2.GrantExpandable) (*v2.Grant, error) {
+	policyResource, err := resourceSdk.NewResource(
+		policyName,
+		resourceTypeIAMPolicy,
+		policyARN,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return grantSdk.NewGrant(
+		policyResource,
+		iamPolicyAttachedEntitlement,
+		principalID,
+		grantSdk.WithAnnotation(expandable),
+	), nil
+}
+
+// customerManagedPolicyARN resolves a permission set's customer-managed policy
+// reference (name + path, no ARN) to the account-local managed policy ARN. The
+// path defaults to "/" and always carries leading and trailing slashes, so the
+// resource segment concatenates to e.g. "policy/division_abc/MyPolicy".
+func customerManagedPolicyARN(accountID string, ref awsSsoAdminTypes.CustomerManagedPolicyReference) string {
+	path := awsSdk.ToString(ref.Path)
+	if path == "" {
+		path = "/"
+	}
+	id := arn.ARN{
+		Partition: awsPartition,
+		Service:   iamType,
+		AccountID: accountID,
+		Resource:  "policy" + path + awsSdk.ToString(ref.Name),
+	}
+	return id.String()
+}
+
+// getManagedPoliciesWithCache lists the AWS-managed policies attached to a
+// permission set, session-cached per permission set so the per-binding fan-out
+// (one binding per account the set is assigned to) costs one API crawl total.
+func (o *permissionSetAssignmentResourceType) getManagedPoliciesWithCache(
+	ctx context.Context,
+	ss sessions.SessionStore,
+	permissionSetArn string,
+) ([]awsSsoAdminTypes.AttachedManagedPolicy, error) {
+	return getOrSetCache(ctx, ss, "aws-connector-ps-managed-policies:"+permissionSetArn, func() ([]awsSsoAdminTypes.AttachedManagedPolicy, error) {
+		var policies []awsSsoAdminTypes.AttachedManagedPolicy
+		input := &awsSsoAdmin.ListManagedPoliciesInPermissionSetInput{
+			InstanceArn:      o.account.identityInstance.InstanceArn,
+			PermissionSetArn: awsSdk.String(permissionSetArn),
+		}
+		for {
+			resp, err := o.account.ssoAdminClient.ListManagedPoliciesInPermissionSet(ctx, input)
+			if err != nil {
+				var noSuchEntity *awsSsoAdminTypes.ResourceNotFoundException
+				if errors.As(err, &noSuchEntity) {
+					ctxzap.Extract(ctx).Warn("baton-aws: permission set not found, skipping managed policy grants for this permission set",
+						zap.String("permission_set_arn", permissionSetArn),
+						zap.Error(err),
+					)
+					return nil, nil
+				}
+				if isAccessDeniedError(err) {
+					ctxzap.Extract(ctx).Warn("baton-aws: access denied listing managed policies in permission set, skipping managed policy grants for this permission set",
+						zap.String("permission_set_arn", permissionSetArn),
+						zap.Error(err),
+					)
+					return nil, nil
+				}
+				return nil, wrapAWSError(fmt.Errorf("baton-aws: ssoadmin.ListManagedPoliciesInPermissionSet failed: %w", err))
+			}
+			policies = append(policies, resp.AttachedManagedPolicies...)
+			if resp.NextToken == nil || *resp.NextToken == "" {
+				return policies, nil
+			}
+			input.NextToken = resp.NextToken
+		}
+	})
+}
+
+// getCustomerManagedPolicyRefsWithCache lists the customer-managed policy
+// references attached to a permission set, session-cached per permission set.
+func (o *permissionSetAssignmentResourceType) getCustomerManagedPolicyRefsWithCache(
+	ctx context.Context,
+	ss sessions.SessionStore,
+	permissionSetArn string,
+) ([]awsSsoAdminTypes.CustomerManagedPolicyReference, error) {
+	return getOrSetCache(ctx, ss, "aws-connector-ps-customer-policies:"+permissionSetArn, func() ([]awsSsoAdminTypes.CustomerManagedPolicyReference, error) {
+		var refs []awsSsoAdminTypes.CustomerManagedPolicyReference
+		input := &awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput{
+			InstanceArn:      o.account.identityInstance.InstanceArn,
+			PermissionSetArn: awsSdk.String(permissionSetArn),
+		}
+		for {
+			resp, err := o.account.ssoAdminClient.ListCustomerManagedPolicyReferencesInPermissionSet(ctx, input)
+			if err != nil {
+				var noSuchEntity *awsSsoAdminTypes.ResourceNotFoundException
+				if errors.As(err, &noSuchEntity) {
+					ctxzap.Extract(ctx).Warn("baton-aws: permission set not found, skipping customer managed policy grants for this permission set",
+						zap.String("permission_set_arn", permissionSetArn),
+						zap.Error(err),
+					)
+					return nil, nil
+				}
+				if isAccessDeniedError(err) {
+					ctxzap.Extract(ctx).Warn("baton-aws: access denied listing customer managed policy references in permission set, skipping customer managed policy grants for this permission set",
+						zap.String("permission_set_arn", permissionSetArn),
+						zap.Error(err),
+					)
+					return nil, nil
+				}
+				return nil, wrapAWSError(fmt.Errorf("baton-aws: ssoadmin.ListCustomerManagedPolicyReferencesInPermissionSet failed: %w", err))
+			}
+			refs = append(refs, resp.CustomerManagedPolicyReferences...)
+			if resp.NextToken == nil || *resp.NextToken == "" {
+				return refs, nil
+			}
+			input.NextToken = resp.NextToken
+		}
+	})
 }
 
 // Grant reads (account, permission set) from the ScopeBindingTrait on the entitlement's

--- a/pkg/connector/permission_set_assignment_behavior_test.go
+++ b/pkg/connector/permission_set_assignment_behavior_test.go
@@ -13,6 +13,7 @@ import (
 	awsSsoAdminTypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/conductorone/baton-aws/test"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ type fakeSSOAdmin struct {
 	describePermissionSetFn                  func(*awsSsoAdmin.DescribePermissionSetInput) (*awsSsoAdmin.DescribePermissionSetOutput, error)
 	listManagedPoliciesInPermissionSetFn     func(*awsSsoAdmin.ListManagedPoliciesInPermissionSetInput) (*awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput, error)
 	getInlinePolicyForPermissionSetFn        func(*awsSsoAdmin.GetInlinePolicyForPermissionSetInput) (*awsSsoAdmin.GetInlinePolicyForPermissionSetOutput, error)
+	listCustomerManagedPolicyReferencesFn    func(*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput) (*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput, error)
 	listAccountAssignmentsFn                 func(*awsSsoAdmin.ListAccountAssignmentsInput) (*awsSsoAdmin.ListAccountAssignmentsOutput, error)
 	createAccountAssignmentFn                func(*awsSsoAdmin.CreateAccountAssignmentInput) (*awsSsoAdmin.CreateAccountAssignmentOutput, error)
 	deleteAccountAssignmentFn                func(*awsSsoAdmin.DeleteAccountAssignmentInput) (*awsSsoAdmin.DeleteAccountAssignmentOutput, error)
@@ -79,6 +81,17 @@ func (f *fakeSSOAdmin) GetInlinePolicyForPermissionSet(
 		return f.getInlinePolicyForPermissionSetFn(in)
 	}
 	return &awsSsoAdmin.GetInlinePolicyForPermissionSetOutput{}, nil
+}
+
+func (f *fakeSSOAdmin) ListCustomerManagedPolicyReferencesInPermissionSet(
+	_ context.Context,
+	in *awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput,
+	_ ...func(*awsSsoAdmin.Options),
+) (*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput, error) {
+	if f.listCustomerManagedPolicyReferencesFn != nil {
+		return f.listCustomerManagedPolicyReferencesFn(in)
+	}
+	return &awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput{}, nil
 }
 
 func (f *fakeSSOAdmin) ListAccountAssignments(_ context.Context, in *awsSsoAdmin.ListAccountAssignmentsInput, _ ...func(*awsSsoAdmin.Options)) (*awsSsoAdmin.ListAccountAssignmentsOutput, error) {
@@ -443,6 +456,151 @@ func TestInlinePolicyList_PermissionSetParent(t *testing.T) {
 	resources, _, err = empty.List(ctx, psParent, resourceSdk.SyncOpAttrs{})
 	require.NoError(t, err)
 	assert.Empty(t, resources)
+}
+
+// Grants on a binding runs two phases: assignment grants first, then one final page of
+// policy-composition grants — the policy's "attached" entitlement granted to the binding,
+// annotated GrantExpandable through the binding's "assigned" entitlement so assigned
+// users/groups inherit the policy. Customer-managed references resolve to the binding
+// account's local policy ARN (path-aware); AWS-managed policies keep their global ARN.
+func TestPermissionSetAssignmentGrants_PolicyCompositionPhase(t *testing.T) {
+	ctx := context.Background()
+	const managedArn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+
+	sso := &fakeSSOAdmin{
+		listAccountAssignmentsFn: func(in *awsSsoAdmin.ListAccountAssignmentsInput) (*awsSsoAdmin.ListAccountAssignmentsOutput, error) {
+			return &awsSsoAdmin.ListAccountAssignmentsOutput{AccountAssignments: []awsSsoAdminTypes.AccountAssignment{{
+				AccountId:        in.AccountId,
+				PermissionSetArn: in.PermissionSetArn,
+				PrincipalType:    awsSsoAdminTypes.PrincipalTypeUser,
+				PrincipalId:      awsSdk.String(behaviorUserNativeID),
+			}}}, nil
+		},
+		listManagedPoliciesInPermissionSetFn: func(
+			in *awsSsoAdmin.ListManagedPoliciesInPermissionSetInput) (*awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput, error) {
+			assert.Equal(t, testPermissionSetArn, awsSdk.ToString(in.PermissionSetArn))
+			return &awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput{
+				AttachedManagedPolicies: []awsSsoAdminTypes.AttachedManagedPolicy{
+					{Arn: awsSdk.String(managedArn), Name: awsSdk.String("AmazonS3ReadOnlyAccess")},
+				},
+			}, nil
+		},
+		listCustomerManagedPolicyReferencesFn: func(
+			in *awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput) (*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput, error) {
+			assert.Equal(t, testPermissionSetArn, awsSdk.ToString(in.PermissionSetArn))
+			return &awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput{
+				CustomerManagedPolicyReferences: []awsSsoAdminTypes.CustomerManagedPolicyReference{
+					{Name: awsSdk.String("RootPolicy")}, // nil path defaults to "/"
+					{Name: awsSdk.String("DivPolicy"), Path: awsSdk.String("/division_abc/")},
+				},
+			}, nil
+		},
+	}
+	psa := permissionSetAssignmentBuilder(newBehaviorAccount(sso))
+	binding, _ := behaviorBinding(t)
+
+	// Phase 1: assignment grants, with a continuation token to the policies phase.
+	grants, res, err := psa.Grants(ctx, binding, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	assert.Equal(t, resourceTypeSSOUser.Id, grants[0].Principal.Id.ResourceType)
+	require.NotNil(t, res)
+	require.NotEmpty(t, res.NextPageToken)
+
+	// Phase 2: policy-composition grants, terminal page.
+	polGrants, res2, err := psa.Grants(ctx, binding, resourceSdk.SyncOpAttrs{PageToken: pagination.Token{Token: res.NextPageToken}})
+	require.NoError(t, err)
+	require.True(t, res2 == nil || res2.NextPageToken == "")
+	require.Len(t, polGrants, 3)
+
+	wantARNs := []string{
+		managedArn,
+		"arn:aws:iam::" + testAccountID + ":policy/RootPolicy",
+		"arn:aws:iam::" + testAccountID + ":policy/division_abc/DivPolicy",
+	}
+	wantExpandableEnt := resourceTypePermissionSetAssignment.Id + ":" + permissionSetAssignmentObjectID(testPermissionSetArn, testAccountID) + ":assigned"
+	for i, g := range polGrants {
+		assert.Equal(t, resourceTypeIAMPolicy.Id, g.Entitlement.Resource.Id.ResourceType)
+		assert.Equal(t, wantARNs[i], g.Entitlement.Resource.Id.Resource)
+		assert.Equal(t, resourceTypeIAMPolicy.Id+":"+wantARNs[i]+":"+iamPolicyAttachedEntitlement, g.Entitlement.Id)
+		// Principal is the binding itself; expansion flows through its "assigned" entitlement.
+		assert.Equal(t, resourceTypePermissionSetAssignment.Id, g.Principal.Id.ResourceType)
+		assert.Equal(t, binding.Id.Resource, g.Principal.Id.Resource)
+
+		annos := annotations.Annotations(g.Annotations)
+		expandable := &v2.GrantExpandable{}
+		ok, err := annos.Pick(expandable)
+		require.NoError(t, err)
+		require.True(t, ok, "policy-composition grant must carry GrantExpandable")
+		require.Equal(t, []string{wantExpandableEnt}, expandable.EntitlementIds)
+	}
+}
+
+// AccessDenied / ResourceNotFound on the policy-composition list APIs must degrade
+// gracefully (warn + skip), matching permission_set.Grants — so upgrades that add
+// sso:ListCustomerManagedPolicyReferencesInPermissionSet before IAM policies are
+// updated don't hard-fail the binding grants sync.
+func TestPermissionSetAssignmentGrants_PolicyComposition_AccessDeniedSkips(t *testing.T) {
+	ctx := context.Background()
+	sso := &fakeSSOAdmin{
+		listAccountAssignmentsFn: func(in *awsSsoAdmin.ListAccountAssignmentsInput) (*awsSsoAdmin.ListAccountAssignmentsOutput, error) {
+			return &awsSsoAdmin.ListAccountAssignmentsOutput{AccountAssignments: []awsSsoAdminTypes.AccountAssignment{{
+				AccountId:        in.AccountId,
+				PermissionSetArn: in.PermissionSetArn,
+				PrincipalType:    awsSsoAdminTypes.PrincipalTypeUser,
+				PrincipalId:      awsSdk.String(behaviorUserNativeID),
+			}}}, nil
+		},
+		listManagedPoliciesInPermissionSetFn: func(
+			_ *awsSsoAdmin.ListManagedPoliciesInPermissionSetInput) (*awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput, error) {
+			return nil, &awsSsoAdminTypes.AccessDeniedException{Message: awsSdk.String("not authorized")}
+		},
+		listCustomerManagedPolicyReferencesFn: func(
+			_ *awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput) (*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput, error) {
+			return nil, &awsSsoAdminTypes.AccessDeniedException{Message: awsSdk.String("not authorized")}
+		},
+	}
+	psa := permissionSetAssignmentBuilder(newBehaviorAccount(sso))
+	binding, _ := behaviorBinding(t)
+
+	grants, res, err := psa.Grants(ctx, binding, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.NotNil(t, res)
+	require.NotEmpty(t, res.NextPageToken)
+
+	polGrants, res2, err := psa.Grants(ctx, binding, resourceSdk.SyncOpAttrs{PageToken: pagination.Token{Token: res.NextPageToken}})
+	require.NoError(t, err)
+	assert.Empty(t, polGrants)
+	require.True(t, res2 == nil || res2.NextPageToken == "")
+}
+
+func TestPermissionSetAssignmentGrants_PolicyComposition_NotFoundSkips(t *testing.T) {
+	ctx := context.Background()
+	sso := &fakeSSOAdmin{
+		listAccountAssignmentsFn: func(in *awsSsoAdmin.ListAccountAssignmentsInput) (*awsSsoAdmin.ListAccountAssignmentsOutput, error) {
+			return &awsSsoAdmin.ListAccountAssignmentsOutput{}, nil
+		},
+		listManagedPoliciesInPermissionSetFn: func(
+			_ *awsSsoAdmin.ListManagedPoliciesInPermissionSetInput) (*awsSsoAdmin.ListManagedPoliciesInPermissionSetOutput, error) {
+			return nil, &awsSsoAdminTypes.ResourceNotFoundException{Message: awsSdk.String("gone")}
+		},
+		listCustomerManagedPolicyReferencesFn: func(
+			_ *awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput) (*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput, error) {
+			return nil, &awsSsoAdminTypes.ResourceNotFoundException{Message: awsSdk.String("gone")}
+		},
+	}
+	psa := permissionSetAssignmentBuilder(newBehaviorAccount(sso))
+	binding, _ := behaviorBinding(t)
+
+	_, res, err := psa.Grants(ctx, binding, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotEmpty(t, res.NextPageToken)
+
+	polGrants, _, err := psa.Grants(ctx, binding, resourceSdk.SyncOpAttrs{PageToken: pagination.Token{Token: res.NextPageToken}})
+	require.NoError(t, err)
+	assert.Empty(t, polGrants)
 }
 
 // Grant resolves (account, permission set) from the trait and calls CreateAccountAssignment

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -225,6 +225,9 @@ var (
 				"sso:ListPermissionSetsProvisionedToAccount",
 				"sso:DescribePermissionSet",
 				"sso:ListAccountAssignments",
+				// Policy-composition grants (expandable to assigned users/groups)
+				"sso:ListManagedPoliciesInPermissionSet",
+				"sso:ListCustomerManagedPolicyReferencesInPermissionSet",
 				// Provision
 				"sso:CreateAccountAssignment",
 				"sso:DeleteAccountAssignment",

--- a/pkg/connector/ssoadmin_api.go
+++ b/pkg/connector/ssoadmin_api.go
@@ -35,6 +35,11 @@ type ssoAdminAPI interface {
 		params *awsSsoAdmin.GetInlinePolicyForPermissionSetInput,
 		optFns ...func(*awsSsoAdmin.Options),
 	) (*awsSsoAdmin.GetInlinePolicyForPermissionSetOutput, error)
+	ListCustomerManagedPolicyReferencesInPermissionSet(
+		ctx context.Context,
+		params *awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetInput,
+		optFns ...func(*awsSsoAdmin.Options),
+	) (*awsSsoAdmin.ListCustomerManagedPolicyReferencesInPermissionSetOutput, error)
 	ListAccountAssignments(ctx context.Context, params *awsSsoAdmin.ListAccountAssignmentsInput, optFns ...func(*awsSsoAdmin.Options)) (*awsSsoAdmin.ListAccountAssignmentsOutput, error)
 	CreateAccountAssignment(ctx context.Context, params *awsSsoAdmin.CreateAccountAssignmentInput, optFns ...func(*awsSsoAdmin.Options)) (*awsSsoAdmin.CreateAccountAssignmentOutput, error)
 	DeleteAccountAssignment(ctx context.Context, params *awsSsoAdmin.DeleteAccountAssignmentInput, optFns ...func(*awsSsoAdmin.Options)) (*awsSsoAdmin.DeleteAccountAssignmentOutput, error)


### PR DESCRIPTION
The readme permissions were out of date, and a couple of permissions weren't set in permission set resource type.

Also we weren't syncing customer-managed policies on permission sets, just inline and AWS managed policies. Fix that gap.