### PR TITLE
docs: add three missing config flags to the README usage block

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Available Commands:
 Flags:
       --client-id string                                 The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
       --client-secret string                             The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
+      --create-account-resource-type string              Which AWS user type C1 should create when provisioning accounts: "iam_user" (default) or "sso_user" ($BATON_CREATE_ACCOUNT_RESOURCE_TYPE) (default "iam_user")
       --external-id string                               The external id for the aws account ($BATON_EXTERNAL_ID)
       --external-resource-c1z string                     The path to the c1z file to sync external baton resources with ($BATON_EXTERNAL_RESOURCE_C1Z)
       --external-resource-entitlement-id-filter string   The entitlement that external users, groups must have access to sync external baton resources ($BATON_EXTERNAL_RESOURCE_ENTITLEMENT_ID_FILTER)
@@ -114,8 +115,10 @@ Flags:
   -p, --provisioning                                     This must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
       --role-arn string                                  The role arn for the aws account ($BATON_ROLE_ARN)
       --skip-full-sync                                   This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
+      --sync-only-attached-policies                      Only sync IAM managed policies that are attached to at least one user, role, or group ($BATON_SYNC_ONLY_ATTACHED_POLICIES)
       --sync-resources strings                           The resource IDs to sync ($BATON_SYNC_RESOURCES)
       --sync-secrets                                     Whether to sync secrets or not ($BATON_SYNC_SECRETS)
+      --sync-sso-user-last-login                         Enable fetching last login time for SSO users from CloudTrail (requires cloudtrail:LookupEvents permission) ($BATON_SYNC_SSO_USER_LAST_LOGIN)
       --ticketing                                        This must be set to enable ticketing support ($BATON_TICKETING)
       --use-assume                                       Enable support for assume role ($BATON_USE_ASSUME)
   -v, --version                                          version for baton-aws


### PR DESCRIPTION
## Summary

The README CLI usage block is hand-maintained (no generation marker, no make target), and it had drifted from `pkg/config/config.go`. Diffing the registered fields against the block, **three flags were undocumented**:

| Flag | Introduced | Notes |
| :--- | :--- | :--- |
| `--sync-sso-user-last-login` | #98 (CXP-15) | Requires `cloudtrail:LookupEvents` |
| `--sync-only-attached-policies` | #132 | Gates `OnlyAttached` on `ListPolicies` (`pkg/connector/iam_policy.go:130`) |
| `--create-account-resource-type` | — | Already referenced in `docs/connector.mdx` as `BATON_CREATE_ACCOUNT_RESOURCE_TYPE`, but never in the README |

Descriptions are copied verbatim from the field definitions (`config.go:123-128`, `:129-133`, and the `create-account-resource-type` `SelectField`) so the block matches real `--help` output. Flags are inserted in alphabetical position, consistent with the rest of the block.

## Relationship to #111

The `--sync-sso-user-last-login` line originates from **#111** by @carolinaroncaglia. That PR bundled two unrelated things:

- the README flag line — **still valid**, carried forward here;
- removing orphaned `SCIMToken` / `SCIMEndpoint` / `SCIMEnabled` struct fields plus the SCIM references in `docs/connector.mdx` — **since resolved independently**; `SCIM` now appears nowhere in the repo outside `vendor/`.

#111 is also `CONFLICTING` against current `main`. This PR carries the surviving change so #111 can be closed without losing it.

While verifying, I found the other two flags were missing too, so this fixes the block rather than one line of it. After this change, **no flag registered in `config.go` is absent from the README** (verified programmatically).

## Test plan

- [x] Every flag name in `config.go` now appears in `README.md` — 0 remaining
- [x] Descriptions match the field definitions verbatim
- [x] Alphabetical ordering preserved in the usage block

Docs-only; no Go changes.

Closes #111 (carrying its still-valid change). Related: #98, #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)